### PR TITLE
Remove log.info for permissions body

### DIFF
--- a/stream-access-control/access-control-core/src/main/java/com/backbase/stream/service/AccessGroupService.java
+++ b/stream-access-control/access-control-core/src/main/java/com/backbase/stream/service/AccessGroupService.java
@@ -198,7 +198,6 @@ public class AccessGroupService {
 
     public Mono<BatchProductGroupTask> assignPermissionsBatch(BatchProductGroupTask task, Map<User, Map<BusinessFunctionGroup, List<BaseProductGroup>>> usersPermissions) {
 
-        log.info("\n****************** ASSIGNING PERMISSSION!! *********************\n: {}", usersPermissions);
         List<PresentationAssignUserPermissions> request = usersPermissions.keySet().stream()
             .map(user -> new PresentationAssignUserPermissions()
                 .externalUserId(user.getExternalId())


### PR DESCRIPTION
Removing this log as it's unnecessary, there are other logs in place already for printing user permission update

```
****************** ASSIGNING PERMISSSION!! *********************
: {class User {
    internalId: ab242eb5-faa4-48cf-b1b5-abe528605547
    externalId: 12345670
    legalEntityId: 8a808639751dd8020175317478300034
    emailAddress: null
    mobileNumber: null
    fullName: Mustafa Keles
    limit: null
    additions: null
    attributes: null
    identityLinkStrategy: IDENTITY_AGNOSTIC
}={class BusinessFunctionGroup {
    id: 8a808639751dd8020175313c859a0005
    legalEntityId: null
    serviceAgreementId: 8a808639751dd8020175313c81070001
    name: Cuenta DNI
    description: Cuenta DNI Permissions
    type: TEMPLATE
    dataGroupsAllowed: null
    functions: null
}=[]}}
```