### PR TITLE
Exclude 'snakeyaml' from 'javafaker' as it conflicts with 'jackson-da…

### DIFF
--- a/stream-audit/audit-core/pom.xml
+++ b/stream-audit/audit-core/pom.xml
@@ -37,6 +37,12 @@
             <groupId>com.github.javafaker</groupId>
             <artifactId>javafaker</artifactId>
             <version>1.0.2</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.yaml</groupId>
+                    <artifactId>snakeyaml</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
     </dependencies>

--- a/stream-legal-entity/legal-entity-generator-core/pom.xml
+++ b/stream-legal-entity/legal-entity-generator-core/pom.xml
@@ -38,6 +38,12 @@
             <groupId>com.github.javafaker</groupId>
             <artifactId>javafaker</artifactId>
             <version>1.0.2</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.yaml</groupId>
+                    <artifactId>snakeyaml</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/stream-product/product-generator-core/pom.xml
+++ b/stream-product/product-generator-core/pom.xml
@@ -44,6 +44,12 @@
             <groupId>com.github.javafaker</groupId>
             <artifactId>javafaker</artifactId>
             <version>1.0.2</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.yaml</groupId>
+                    <artifactId>snakeyaml</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/stream-sdk/stream-parent/stream-test-support/pom.xml
+++ b/stream-sdk/stream-parent/stream-test-support/pom.xml
@@ -42,6 +42,12 @@
             <groupId>com.github.javafaker</groupId>
             <artifactId>javafaker</artifactId>
             <version>1.0.2</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.yaml</groupId>
+                    <artifactId>snakeyaml</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.projectreactor</groupId>

--- a/stream-transactions/transactions-generator-core/pom.xml
+++ b/stream-transactions/transactions-generator-core/pom.xml
@@ -31,6 +31,12 @@
             <groupId>com.github.javafaker</groupId>
             <artifactId>javafaker</artifactId>
             <version>1.0.2</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.yaml</groupId>
+                    <artifactId>snakeyaml</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
…taformat-yaml'

My service tests are failing with exception:
```
java.lang.NoSuchMethodError: 'void org.yaml.snakeyaml.LoaderOptions.setMaxAliasesForCollections(int)'
```
After checking mvn dependency tree, I found a conflict with snakeyaml:
```
[INFO]    +- com.github.javafaker:javafaker:jar:1.0.2:test
[INFO]    |  +- org.yaml:snakeyaml:jar:android:1.23:test
```
```
[INFO] +- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:jar:2.11.0:compile
[INFO] |  +- org.yaml:snakeyaml:jar:1.26:compile
```
After excluding the snakeyaml dependency from javafaker, tests are passing.

It's also included in other module with compile scope so for some cases it will fail just for tests but for some others will do on app startup, so I excluded it from everywhere
```
[INFO] |  +- com.github.javafaker:javafaker:jar:1.0.2:compile
[INFO] |  |  \- org.yaml:snakeyaml:jar:android:1.23:compile
```