### PR TITLE
Fixing NullPointerException for Data group creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [2.30.0]
+### Changed
+- Fixing NullPointerException while creating data group using products i.e. without custom data group id
+
 ## [2.29.0]
 ### Changed
 - Checking the response recieved from Legal entity api , user  api to is2xxSuccessful as it  returns 207 response for success.

--- a/stream-product/product-core/src/main/java/com/backbase/stream/product/utils/StreamUtils.java
+++ b/stream-product/product-core/src/main/java/com/backbase/stream/product/utils/StreamUtils.java
@@ -65,7 +65,7 @@ public class StreamUtils {
     }
 
     public static List<String> getCustomDataGroupItems(BaseProductGroup productGroup) {
-        return productGroup.getCustomDataGroupItems().stream()
+        return nullableCollectionToStream(productGroup.getCustomDataGroupItems())
             .map(CustomDataGroupItem::getInternalId).collect(Collectors.toList());
     }
 


### PR DESCRIPTION
This fix is to avoid NullPointerException when creating data group of type products i.e. without custom data group id.