### PR TITLE
Fixing the delete issue when using reference job roles. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+## [2.31.0]
+### Changed
+- Fixing the function group delete to only happen when it is not template type (this is when using referenceJobRoles )
 
 ## [2.30.0]
 ### Changed

--- a/stream-access-control/access-control-core/src/main/java/com/backbase/stream/service/AccessGroupService.java
+++ b/stream-access-control/access-control-core/src/main/java/com/backbase/stream/service/AccessGroupService.java
@@ -974,9 +974,9 @@ public class AccessGroupService {
             .collectList()
             .flatMap(functionGroups ->
                 functionGroupsApi.postFunctionGroupsDelete(
-                    functionGroups.stream().map(fg -> mapId(fg.getId())).collect(Collectors.toList()))
-                    .map(r -> BatchResponseUtils.checkBatchResponseItem(r, "Function  Group Removal", r.getStatus().getValue(), r.getResourceId(), r.getErrors()))
-                    .collectList())
+                        functionGroups.stream().filter(f->!FunctionGroupItem.TypeEnum.TEMPLATE.equals(f.getType())).map(fg -> mapId(fg.getId())).collect(Collectors.toList()))
+                        .map(r -> BatchResponseUtils.checkBatchResponseItem(r, "Function  Group Removal", r.getStatus().getValue(), r.getResourceId(), r.getErrors()))
+                        .collectList())
             .then();
     }
 


### PR DESCRIPTION
This fix deletes the function groups only if it is not of Template Type. @uesleilima 