### PR TITLE
Fix for previous fix regarding SFG appearing in get permissions response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## [2.40.1]
+## [2.42.0]
+### Fixed
+- Permissions assignment for user marked as admin was working incorrectly due to fact that System Function Group was returned when no assigned groups expected
+
+## [2.41.0]
 ### Changed
 - Add filter to forward `X-TID` headers
 

--- a/stream-access-control/access-control-core/src/test/java/com/backbase/stream/service/AccessGroupServiceTest.java
+++ b/stream-access-control/access-control-core/src/test/java/com/backbase/stream/service/AccessGroupServiceTest.java
@@ -386,8 +386,8 @@ class AccessGroupServiceTest {
 
     /*
        Request contains business-function-group-id-1
-       Existing permissions are system-group-id-1 and business-function-group-id-1
-       Expectation is to have all these two function groups in PUT permissions request together with data group ids specified in request
+       Existing permissions are: system-group-id-1, function-group-id-1 and business-function-group-id-1
+       Expectation is to have function-group-id-1 and business-function-group-id-1 in PUT permissions request together with data group ids specified in request
      */
     @Test
     void assignPermissionsBatchNoExistingFunctionGroups() {
@@ -415,7 +415,7 @@ class AccessGroupServiceTest {
                 .externalServiceAgreementId("sa_benedict")
                 .functionGroupDataGroups(Arrays.asList(
                     new PresentationFunctionGroupDataGroup().functionGroupIdentifier(
-                        new PresentationIdentifier().idIdentifier("system-group-id-1")
+                        new PresentationIdentifier().idIdentifier("function-group-id-1")
                     ).dataGroupIdentifiers(Collections.emptyList()),
                     new PresentationFunctionGroupDataGroup().functionGroupIdentifier(
                         new PresentationIdentifier().idIdentifier("business-function-group-id-1")
@@ -427,11 +427,14 @@ class AccessGroupServiceTest {
         );
 
         when(functionGroupApi.getFunctionGroups("sa-internal-id"))
-            .thenReturn(Flux.just());
+            .thenReturn(Flux.just(
+                new FunctionGroupItem().id("system-group-id-1").name("SFG").type(FunctionGroupItem.TypeEnum.SYSTEM),
+                new FunctionGroupItem().id("function-group-id-1").name("Full access").type(FunctionGroupItem.TypeEnum.TEMPLATE)
+            ));
 
         when(userQueryApi.getPersistenceApprovalPermissions("user-internal-id", "sa-internal-id"))
             .thenReturn(Mono.just(new PersistenceApprovalPermissions().items(Arrays.asList(
-                new PersistenceApprovalPermissionsGetResponseBody().functionGroupId("system-group-id-1").dataGroupIds(Collections.emptyList()),
+                new PersistenceApprovalPermissionsGetResponseBody().functionGroupId("function-group-id-1").dataGroupIds(Collections.emptyList()),
                 new PersistenceApprovalPermissionsGetResponseBody().functionGroupId("business-function-group-id-1").dataGroupIds(Collections.singletonList("data-group-1"))
             ))));
 


### PR DESCRIPTION
In general filtering logic was moved slightly upper in order to preserve original code that would assign given permissions in request when none returned from API