### PR TITLE
Non existing Business function groups from the request should be pers…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [2.46.2]
+### Changed
+- Non existing Business function groups from the request should be persisted.  
+
 ## [2.46.1]
 ### Changed
 - Setting consistent DBS default values for access control token used by delete operations.

--- a/stream-access-control/access-control-core/src/main/java/com/backbase/stream/service/AccessGroupService.java
+++ b/stream-access-control/access-control-core/src/main/java/com/backbase/stream/service/AccessGroupService.java
@@ -623,7 +623,7 @@ public class AccessGroupService {
                     if (existingUserPermissions.isEmpty()) {
                         mergedUserPermissions.setFunctionGroupDataGroups(requestUserPermissions.getFunctionGroupDataGroups());
                     } else {
-                        //convert all persisted existing permissions to final merged list
+                        //Convert all persisted permissions and adding them to final merged list
                         existingUserPermissions.forEach(userPermission -> {
                             Set<String> dataGroupIds = new HashSet<>();
                             if (userPermission.getDataGroupIds() != null) {

--- a/stream-access-control/access-control-core/src/test/java/com/backbase/stream/service/AccessGroupServiceTest.java
+++ b/stream-access-control/access-control-core/src/test/java/com/backbase/stream/service/AccessGroupServiceTest.java
@@ -352,6 +352,9 @@ class AccessGroupServiceTest {
                     ).dataGroupIdentifiers(Collections.emptyList()),
                     new PresentationFunctionGroupDataGroup().functionGroupIdentifier(
                         new PresentationIdentifier().idIdentifier("system-group-id-3")
+                    ).dataGroupIdentifiers(Collections.emptyList()),
+                    new PresentationFunctionGroupDataGroup().functionGroupIdentifier(
+                        new PresentationIdentifier().idIdentifier("business-function-group-id-1")
                     ).dataGroupIdentifiers(Collections.emptyList())
                 ))
         );
@@ -385,7 +388,7 @@ class AccessGroupServiceTest {
     }
 
     /*
-       Request contains business-function-group-id-1
+       Request contains business-function-group-id-1, business-function-group-id-2
        Existing permissions are: system-group-id-1, function-group-id-1 and business-function-group-id-1
        Expectation is to have function-group-id-1 and business-function-group-id-1 in PUT permissions request together with data group ids specified in request
      */
@@ -401,6 +404,10 @@ class AccessGroupServiceTest {
         baseProductGroupMap.put(
             new BusinessFunctionGroup().id("business-function-group-id-1"),
             Collections.singletonList(new BaseProductGroup().internalId("data-group-0"))
+        );
+        baseProductGroupMap.put(
+             new BusinessFunctionGroup().id("business-function-group-id-2"),
+             Collections.singletonList(new BaseProductGroup().internalId("data-group-2"))
         );
 
         Map<User, Map<BusinessFunctionGroup, List<BaseProductGroup>>> usersPermissions = new HashMap<>();
@@ -421,10 +428,14 @@ class AccessGroupServiceTest {
                         new PresentationIdentifier().idIdentifier("business-function-group-id-1")
                     ).dataGroupIdentifiers(Arrays.asList(
                         new PresentationIdentifier().idIdentifier("data-group-1"),
-                        new PresentationIdentifier().idIdentifier("data-group-0")
-                    ))
+                        new PresentationIdentifier().idIdentifier("data-group-0"))),
+                    new PresentationFunctionGroupDataGroup().functionGroupIdentifier(
+                        new PresentationIdentifier().idIdentifier("business-function-group-id-2")
+                    ).dataGroupIdentifiers(Arrays.asList(
+                        new PresentationIdentifier().idIdentifier("data-group-2")
+                    )
                 ))
-        );
+        ));
 
         when(functionGroupApi.getFunctionGroups("sa-internal-id"))
             .thenReturn(Flux.just(

--- a/stream-access-control/access-control-core/src/test/java/com/backbase/stream/service/AccessGroupServiceTest.java
+++ b/stream-access-control/access-control-core/src/test/java/com/backbase/stream/service/AccessGroupServiceTest.java
@@ -389,8 +389,8 @@ class AccessGroupServiceTest {
 
     /*
        Request contains business-function-group-id-1, business-function-group-id-2
-       Existing permissions are: system-group-id-1, function-group-id-1 and business-function-group-id-1
-       Expectation is to have function-group-id-1 and business-function-group-id-1 in PUT permissions request together with data group ids specified in request
+       Existing permissions are: system-group-id-1, function-group-id-1, business-function-group-id-1 and business-function-group-id-2
+       Expectation is to have function-group-id-1, business-function-group-id-1 and business-function-group-id-2 in PUT permissions request together with data group ids specified in request
      */
     @Test
     void assignPermissionsBatchNoExistingFunctionGroups() {


### PR DESCRIPTION
Non existing Business function groups from the request should be pers…

Previously only data groups from the existing BFG were merged. And BFG was skipped in case if it's a new one.