### PR TITLE
Deleting existing user's permissions in LegalEntitySaga.processTask

### DIFF
--- a/stream-legal-entity/legal-entity-core/src/test/java/com/backbase/stream/LegalEntitySagaTest.java
+++ b/stream-legal-entity/legal-entity-core/src/test/java/com/backbase/stream/LegalEntitySagaTest.java
@@ -87,8 +87,11 @@ class LegalEntitySagaTest {
                     new LegalEntity().externalId(leExternalId).customServiceAgreement(customSa)
             ));
 
+        ServiceAgreement serviceAgreement = new ServiceAgreement();
+
         LegalEntityTask task = mockLegalEntityTask(legalEntity);
 
+        when(legalEntityService.getMasterServiceAgreementForExternalLegalEntityId(eq(leExternalId))).thenReturn(Mono.just(serviceAgreement));
         when(legalEntityService.getLegalEntityByExternalId(eq(leExternalId))).thenReturn(Mono.empty());
         when(legalEntityService.createLegalEntity(any())).thenReturn(Mono.just(legalEntity));
         when(accessGroupService.getServiceAgreementByExternalId(eq(customSaExId))).thenReturn(Mono.empty());
@@ -134,8 +137,10 @@ class LegalEntitySagaTest {
         LegalEntity legalEntity = new LegalEntity().externalId(leExternalId).customServiceAgreement(customSa)
             .productGroups(Collections.singletonList(productGroup));
 
+        ServiceAgreement serviceAgreement = new ServiceAgreement();
         LegalEntityTask task = mockLegalEntityTask(legalEntity);
 
+        when(legalEntityService.getMasterServiceAgreementForExternalLegalEntityId(eq(leExternalId))).thenReturn(Mono.just(serviceAgreement));
         when(legalEntityService.getLegalEntityByExternalId(eq(leExternalId))).thenReturn(Mono.empty());
         when(legalEntityService.createLegalEntity(any())).thenReturn(Mono.just(legalEntity));
         when(accessGroupService.getServiceAgreementByExternalId(eq(customSaExId))).thenReturn(Mono.empty());


### PR DESCRIPTION
Delete existing user's permissions when creating/updating legal entity (before assigning new ones).

In current implementation, when legal entity already exists and there are existing function groups with different names (different than passed in LegalEntity object), then they are not touched by LegalEntitySaga.executeTask. This may lead to the scenario when unwanted permissions (and function groups) stays active.