### PR TITLE
Bump the maven group across 2 directories with 1 update

### DIFF
--- a/stream-compositions/services/pom.xml
+++ b/stream-compositions/services/pom.xml
@@ -17,7 +17,7 @@
     <name>Stream :: Compositions :: Services</name>
 
     <properties>
-        <activemq.version>6.1.3</activemq.version>
+        <activemq.version>6.2.4</activemq.version>
     </properties>
 
     <modules>

--- a/stream-compositions/test-utils/pom.xml
+++ b/stream-compositions/test-utils/pom.xml
@@ -20,7 +20,7 @@
         <findMainClass.skip>true</findMainClass.skip>
         <spring-boot.repackage.skip>true</spring-boot.repackage.skip>
         <mockito.version>5.2.0</mockito.version>
-        <activemq.version>6.1.3</activemq.version>
+        <activemq.version>6.2.4</activemq.version>
         <!-- TODO: This module shouldn't be inheriting from SSDK Starter Parent, disabling Jib plugin as workaround -->
         <docker.distroless.tag.skip>true</docker.distroless.tag.skip>
         <docker.distroless.latest.skip>true</docker.distroless.latest.skip>


### PR DESCRIPTION
Bumps the maven group with 1 update in the /stream-compositions/services directory: [org.apache.activemq:activemq-broker](https://github.com/apache/activemq).
Bumps the maven group with 1 update in the /stream-compositions/test-utils directory: [org.apache.activemq:activemq-broker](https://github.com/apache/activemq).


Updates `org.apache.activemq:activemq-broker` from 6.1.3 to 6.2.4
- [Release notes](https://github.com/apache/activemq/releases)
- [Commits](https://github.com/apache/activemq/compare/activemq-6.1.3...activemq-6.2.4)

Updates `org.apache.activemq:activemq-broker` from 6.1.3 to 6.2.4
- [Release notes](https://github.com/apache/activemq/releases)
- [Commits](https://github.com/apache/activemq/compare/activemq-6.1.3...activemq-6.2.4)

---
updated-dependencies:
- dependency-name: org.apache.activemq:activemq-broker dependency-version: 6.2.4 dependency-type: direct:development dependency-group: maven
- dependency-name: org.apache.activemq:activemq-broker dependency-version: 6.2.4 dependency-type: direct:production dependency-group: maven ...

## Description

A few sentences describing the overall goals of the pull request's commits.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
  
  Add N/A to the task if they are not relevant to the current PR(validation will be skipped). 
  e.g. [ ] My changes are adequately tested ~ N/A
-->

 - [ ] I made sure, I read [CONTRIBUTING.md](CONTRIBUTING.md) to put right branch prefix as per my need.
 - [ ] I made sure to update [CHANGELOG.md](CHANGELOG.md).
 - [ ] I made sure to update [Stream Wiki](https://github.com/Backbase/stream-services/wiki)(only valid in case of new stream module or architecture changes).
 - [ ] My changes are adequately tested.
 - [ ] I made sure all the SonarCloud Quality Gate are passed.
