### PR TITLE
fix update data group items request to access-control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [8.1.4](https://github.com/Backbase/stream-services/compare/8.1.3...8.1.4)
+### Changed
+- Fix update data group items request to access-control (use externalDataItemIds instead of internal)
+
 ## [8.1.3](https://github.com/Backbase/stream-services/compare/8.1.2...8.1.3)
 ### Changed
 - Added dependency validation to stream-compositions services pom.xml to fix product validation issues for arrangements with additional properties.

--- a/stream-access-control/access-control-core/src/main/java/com/backbase/stream/configuration/AccessControlConfiguration.java
+++ b/stream-access-control/access-control-core/src/main/java/com/backbase/stream/configuration/AccessControlConfiguration.java
@@ -7,6 +7,7 @@ import com.backbase.accesscontrol.functiongroup.api.service.v1.FunctionGroupApi;
 import com.backbase.accesscontrol.permissioncheck.api.service.v1.PermissionCheckApi;
 import com.backbase.accesscontrol.serviceagreement.api.service.v1.ServiceAgreementApi;
 import com.backbase.accesscontrol.usercontext.api.service.v1.UserContextApi;
+import com.backbase.dbs.arrangement.api.service.v3.ArrangementsApi;
 import com.backbase.dbs.user.api.service.v2.IdentityManagementApi;
 import com.backbase.dbs.user.api.service.v2.UserManagementApi;
 import com.backbase.dbs.user.profile.api.service.v2.UserProfileManagementApi;
@@ -82,6 +83,7 @@ public class AccessControlConfiguration {
     @Bean
     public AccessGroupService accessGroupService(
         UserManagementApi usersApi,
+        ArrangementsApi arrangementsApi,
         DeletionProperties configurationProperties,
         BatchResponseUtils batchResponseUtils,
         AccessControlConfigurationProperties accessControlConfigurationProperties,
@@ -95,7 +97,7 @@ public class AccessControlConfiguration {
         AssignPermissionsApi assignPermissionsApi,
         com.backbase.accesscontrol.assignpermissions.api.integration.v1.AssignPermissionsApi assignPermissionsIntegrationApi,
         UserContextApi userContextApi) {
-        return new AccessGroupService(usersApi, batchResponseUtils, configurationProperties,
+        return new AccessGroupService(usersApi, arrangementsApi, batchResponseUtils, configurationProperties,
             accessControlConfigurationProperties,
             permissionCheckApi, dataGroupServiceApi, dataGroupIntegrationApi, functionGroupServiceApi,
             functionGroupIntegrationApi,

--- a/stream-access-control/access-control-core/src/main/java/com/backbase/stream/service/AccessGroupService.java
+++ b/stream-access-control/access-control-core/src/main/java/com/backbase/stream/service/AccessGroupService.java
@@ -42,6 +42,10 @@ import com.backbase.accesscontrol.serviceagreement.api.service.v1.model.Particip
 import com.backbase.accesscontrol.serviceagreement.api.service.v1.model.ServiceAgreementParticipants;
 import com.backbase.accesscontrol.serviceagreement.api.service.v1.model.ServiceAgreementUpdateRequest;
 import com.backbase.accesscontrol.usercontext.api.service.v1.UserContextApi;
+import com.backbase.dbs.arrangement.api.service.v3.ArrangementsApi;
+import com.backbase.dbs.arrangement.api.service.v3.model.ArrangementItem;
+import com.backbase.dbs.arrangement.api.service.v3.model.ArrangementSearchesListResponse;
+import com.backbase.dbs.arrangement.api.service.v3.model.ArrangementsSearchesPostRequest;
 import com.backbase.dbs.user.api.service.v2.UserManagementApi;
 import com.backbase.dbs.user.api.service.v2.model.GetUser;
 import com.backbase.stream.configuration.AccessControlConfigurationProperties;
@@ -78,6 +82,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumMap;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -125,6 +130,8 @@ public class AccessGroupService {
 
     @NonNull
     private final UserManagementApi usersApi;
+    @NonNull
+    private final ArrangementsApi arrangementsApiService;
     @NonNull
     private final BatchResponseUtils batchResponseUtils;
     @NonNull
@@ -195,7 +202,6 @@ public class AccessGroupService {
     }
 
     /**
-     *
      * @param streamTask
      * @param serviceAgreement
      * @return Service Agreement
@@ -611,7 +617,8 @@ public class AccessGroupService {
                     "Assigning permissions: %s",
                     userPermissionsList.stream().map(this::prettyPrintUserAssignedPermissions)
                         .collect(Collectors.joining(",")));
-                return assignPermissionsIntegrationApi.batchUpdateUserPermissions(map(userPermissionsList))
+                return Flux.fromIterable(partitionList(map(userPermissionsList), 1000))
+                    .flatMap(assignPermissionsIntegrationApi::batchUpdateUserPermissions)
                     .map(r -> batchResponseUtils.checkBatchResponseItem(r, "Permissions Update",
                         r.getStatus().toString(), r.getResourceId(), r.getErrors()))
                     .doOnNext(
@@ -970,65 +977,105 @@ public class AccessGroupService {
     public Mono<BatchProductGroupTask> updateExistingDataGroupsBatch(BatchProductGroupTask task,
         List<DataGroup> existingDataGroups, List<BaseProductGroup> productGroups) {
         List<DataItemBatchUpdate> batchUpdateRequest = new ArrayList<>();
-        final Set<String> affectedArrangements = Stream.concat(
-                productGroups.stream().map(StreamUtils::getInternalProductIds).flatMap(List::stream),
-                productGroups.stream().map(BaseProductGroup::getCustomDataGroupItems).flatMap(List::stream)
-                    .map(CustomDataGroupItem::getInternalId))
-            .collect(Collectors.toSet());
-        if (task.getIngestionMode().isDataGroupsReplaceEnabled()) {
-            // if REPLACE mode, existing products (not sent in the request) also need to be added to the set of affected arrangements.
-            affectedArrangements.addAll(existingDataGroups.stream()
-                .map(DataGroup::getItems)
-                .flatMap(Set::stream)
-                .collect(Collectors.toSet())
-            );
-        }
+        final Map<String, String> affectedArrangementsInternalToExternalIds = Stream.concat(
+                productGroups.stream()
+                    .flatMap(StreamUtils::getAllProducts)
+                    .filter(Objects::nonNull)
+                    .map(p -> new java.util.AbstractMap.SimpleEntry<>(p.getInternalId(), p.getExternalId())),
+                productGroups.stream()
+                    .map(BaseProductGroup::getCustomDataGroupItems)
+                    .filter(Objects::nonNull)
+                    .flatMap(List::stream)
+                    .map(i -> new java.util.AbstractMap.SimpleEntry<>(i.getInternalId(), i.getExternalId())))
+            .filter(e -> e.getKey() != null && e.getValue() != null)
+            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, (a, b) -> a));
 
-        existingDataGroups.forEach(dbsDataGroup -> {
-            // get group matching  DBS one.
-            Optional<BaseProductGroup> pg = productGroups.stream()
-                .filter(it -> isEquals(it, dbsDataGroup))
-                .findFirst();
-            Set<String> arrangementsToAdd = new HashSet<>();
-            Set<String> arrangementsToRemove = new HashSet<>();
-            affectedArrangements.forEach(arrangement -> pg.ifPresent(p -> {
-                boolean shouldBeInGroup = StreamUtils.getInternalProductIds(pg.get()).contains(arrangement) ||
-                    pg.get().getCustomDataGroupItems().stream().map(CustomDataGroupItem::getInternalId)
-                        .anyMatch(arrangement::equals);
-                if (!dbsDataGroup.getItems().contains(arrangement) && shouldBeInGroup) {
-                    // ADD.
-                    log.debug("Arrangement item {} to be added to Data Group {}", arrangement, dbsDataGroup.getName());
-                    arrangementsToAdd.add(arrangement);
-                }
-                if (dbsDataGroup.getItems().contains(arrangement) && !shouldBeInGroup) {
-                    // remove.
-                    log.debug("Arrangement item {} to be removed from Data Group {}", arrangement,
-                        dbsDataGroup.getName());
-                    arrangementsToRemove.add(arrangement);
-                }
-            }));
-            if (!CollectionUtils.isEmpty(arrangementsToAdd)) {
-                batchUpdateRequest.add(new DataItemBatchUpdate()
-                    .dataGroupIdentifier(new DataGroupNameIdentifier()
-                        .name(dbsDataGroup.getName())
-                        .dataGroupType(dbsDataGroup.getType())
-                        .externalServiceAgreementId(task.getData().getServiceAgreement().getExternalId()))
-                    .action(Action.ADD)
-                    .dataItems(arrangementsToAdd)
-                );
+        Mono<Map<String, String>> affectedArrangementsMono =
+            // if REPLACE mode, existing products (not sent in the request) also need to be added to the set of affected arrangements.
+            task.getIngestionMode().isDataGroupsReplaceEnabled()
+                ? Mono.defer(() -> {
+                    Set<String> existingInternalIds = existingDataGroups.stream()
+                        .map(DataGroup::getItems)
+                        .filter(Objects::nonNull)
+                        .flatMap(Set::stream)
+                        .collect(Collectors.toSet());
+                    if (existingInternalIds.isEmpty()) {
+                        return Mono.just(affectedArrangementsInternalToExternalIds);
+                    }
+                    // Fetch external ids for existing arrangements (used to call access-control api to add/remove data group items).
+                    return arrangementsApiService.postSearchArrangements(
+                            new ArrangementsSearchesPostRequest()
+                                .arrangementIds(existingInternalIds)
+                                .size(existingInternalIds.size()))
+                        .map(ArrangementSearchesListResponse::getArrangementElements)
+                        .defaultIfEmpty(Collections.emptyList())
+                        .map(items -> {
+                            Map<String, String> merged = new HashMap<>(affectedArrangementsInternalToExternalIds);
+                            items.forEach(item -> {
+                                if (existingInternalIds.contains(item.getId())) {
+                                    merged.putIfAbsent(item.getId(), item.getExternalArrangementId());
+                                }
+                            });
+                            return merged;
+                        });
             }
-            if (!CollectionUtils.isEmpty(arrangementsToRemove)) {
-                batchUpdateRequest.add(new DataItemBatchUpdate()
-                    .dataGroupIdentifier(new DataGroupNameIdentifier()
-                        .name(dbsDataGroup.getName())
-                        .dataGroupType(dbsDataGroup.getType())
-                        .externalServiceAgreementId(task.getData().getServiceAgreement().getExternalId()))
-                    .action(Action.REMOVE)
-                    .dataItems(arrangementsToRemove)
-                );
+            ) : Mono.just(affectedArrangementsInternalToExternalIds);
+
+        return affectedArrangementsMono.flatMap(affectedArrangements -> {
+            existingDataGroups.forEach(dbsDataGroup -> {
+                // get group matching  DBS one.
+                Optional<BaseProductGroup> pg = productGroups.stream()
+                    .filter(it -> isEquals(it, dbsDataGroup))
+                    .findFirst();
+                // it should be external data item ids (both add and remove)
+                Set<String> arrangementsToAdd = new HashSet<>();
+                Set<String> arrangementsToRemove = new HashSet<>();
+                affectedArrangements.forEach((internalId, externalId) -> pg.ifPresent(p -> {
+                    boolean shouldBeInGroup =
+                        StreamUtils.getInternalProductIds(pg.get()).contains(internalId) ||
+                            pg.get().getCustomDataGroupItems().stream()
+                                .map(CustomDataGroupItem::getInternalId)
+                                .anyMatch(internalId::equals);
+                    if (dbsDataGroup.getItems() != null && !dbsDataGroup.getItems().contains(internalId) && shouldBeInGroup) {
+                        // ADD.
+                        log.debug("Arrangement item {} with External Id {} to be added to Data Group {}",
+                            internalId, externalId, dbsDataGroup.getName());
+                        arrangementsToAdd.add(externalId);
+                    }
+                    if (dbsDataGroup.getItems().contains(internalId) && !shouldBeInGroup) {
+                        // REMOVE.
+                        log.debug("Arrangement item {} with External Id {} to be removed from Data Group {}",
+                            internalId, externalId, dbsDataGroup.getName());
+                        arrangementsToRemove.add(externalId);
+                    }
+                }));
+                if (!CollectionUtils.isEmpty(arrangementsToAdd)) {
+                    batchUpdateRequest.add(new DataItemBatchUpdate()
+                        .dataGroupIdentifier(new DataGroupNameIdentifier()
+                            .name(dbsDataGroup.getName())
+                            .dataGroupType(dbsDataGroup.getType())
+                            .externalServiceAgreementId(task.getData().getServiceAgreement().getExternalId()))
+                        .action(Action.ADD)
+                        .dataItems(arrangementsToAdd)
+                    );
+                }
+                if (!CollectionUtils.isEmpty(arrangementsToRemove)) {
+                    batchUpdateRequest.add(new DataItemBatchUpdate()
+                        .dataGroupIdentifier(new DataGroupNameIdentifier()
+                            .name(dbsDataGroup.getName())
+                            .dataGroupType(dbsDataGroup.getType())
+                            .externalServiceAgreementId(task.getData().getServiceAgreement().getExternalId()))
+                        .action(Action.REMOVE)
+                        .dataItems(arrangementsToRemove)
+                    );
+                }
+            });
+            if (CollectionUtils.isEmpty(batchUpdateRequest)) {
+                log.debug("All Product Groups are up to date.");
+                task.info(ACCESS_GROUP, "update", "SUCCESS", prettyPrintProductGroupNames(task), null,
+                    "All Product Groups are up to date.");
+                return Mono.just(task);
             }
-        });
-        if (!CollectionUtils.isEmpty(batchUpdateRequest)) {
             return updateDataGroupItems(batchUpdateRequest)
                 .doOnNext(response ->
                     task.info(ACCESS_GROUP, "update", response.getStatus().toString(), response.getResourceId(), null,
@@ -1044,12 +1091,7 @@ public class AccessGroupService {
                 })
                 .collectList()
                 .thenReturn(task);
-        } else {
-            log.debug("All Product Groups are up to date.");
-            task.info(ACCESS_GROUP, "update", "SUCCESS", prettyPrintProductGroupNames(task), null,
-                "All Product Groups are up to date.");
-            return Mono.just(task);
-        }
+        });
     }
 
     @NotNull

--- a/stream-access-control/access-control-core/src/test/java/com/backbase/stream/service/AccessGroupServiceTest.java
+++ b/stream-access-control/access-control-core/src/test/java/com/backbase/stream/service/AccessGroupServiceTest.java
@@ -9,12 +9,14 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
 
@@ -60,6 +62,10 @@ import com.backbase.accesscontrol.serviceagreement.api.service.v1.model.ServiceA
 import com.backbase.accesscontrol.usercontext.api.service.v1.UserContextApi;
 import com.backbase.accesscontrol.usercontext.api.service.v1.model.ContextServiceAgreement;
 import com.backbase.accesscontrol.usercontext.api.service.v1.model.GetContexts;
+import com.backbase.dbs.arrangement.api.service.v3.ArrangementsApi;
+import com.backbase.dbs.arrangement.api.service.v3.model.ArrangementItem;
+import com.backbase.dbs.arrangement.api.service.v3.model.ArrangementSearchesListResponse;
+import com.backbase.dbs.arrangement.api.service.v3.model.ArrangementsSearchesPostRequest;
 import com.backbase.dbs.user.api.service.v2.UserManagementApi;
 import com.backbase.stream.configuration.AccessControlConfigurationProperties;
 import com.backbase.stream.configuration.DeletionProperties;
@@ -115,6 +121,7 @@ import org.springframework.web.reactive.function.client.WebClientResponseExcepti
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
+import wiremock.org.checkerframework.common.value.qual.ArrayLenRange;
 
 @ExtendWith(MockitoExtension.class)
 class AccessGroupServiceTest {
@@ -123,6 +130,8 @@ class AccessGroupServiceTest {
     private AccessGroupService subject;
     @Mock
     private UserManagementApi usersApi;
+    @Mock
+    ArrangementsApi arrangementsApi;
     @Mock
     private PermissionCheckApi permissionCheckServiceApi;
     @Mock
@@ -592,6 +601,34 @@ class AccessGroupServiceTest {
     }
 
     @Test
+    void assignPermissionsBatch_noPermissions() {
+        // Given
+        BatchProductGroupTask batchProductGroupTask = new BatchProductGroupTask().data(
+            new BatchProductGroup().serviceAgreement(
+                new ServiceAgreement().externalId("sa-external-id").internalId("sa-internal-id"))
+        );
+        batchProductGroupTask.setIngestionMode(BatchProductIngestionMode.UPSERT);
+
+        when(functionGroupServiceApi.getFunctionGroups("sa-internal-id"))
+            .thenReturn(Mono.just(new GetFunctionGroups()
+                .functionGroups(List.of(
+                    new FunctionGroupItem().id("system-group-id-1").type(TypeEnum.SYSTEM),
+                    new FunctionGroupItem().id("system-group-id-2").type(TypeEnum.REFERENCE),
+                    new FunctionGroupItem().id("system-group-id-3").type(TypeEnum.SYSTEM)
+                ))
+            ));
+
+        // When
+        BatchProductGroupTask result = subject.assignPermissionsBatch(batchProductGroupTask, Map.of())
+            .block();
+
+        // Then
+        Assertions.assertSame(batchProductGroupTask, result);
+
+        verify(assignPermissionsIntegrationApi, never()).batchUpdateUserPermissions(anyList());
+    }
+
+    @Test
     void assignPermissionsBatchIngestionModeReplace() {
         // Given
         BatchProductGroupTask batchProductGroupTask = new BatchProductGroupTask().data(
@@ -786,6 +823,18 @@ class AccessGroupServiceTest {
             "Repository Group Engagement Template Notification", BaseProductGroup.ProductGroupTypeEnum.REPOSITORIES,
             "engagement-template-notification");
 
+        when(arrangementsApi.postSearchArrangements(any()))
+            .thenReturn(
+                Mono.just(new ArrangementSearchesListResponse()
+                    .arrangementElements(
+                        List.of(
+                            new ArrangementItem().id("template-custom-test")
+                                .externalArrangementId("template-custom-test-ext"),
+                            new ArrangementItem().id("engagement-template-custom-test")
+                                .externalArrangementId("engagement-template-custom-test-ext"),
+                            new ArrangementItem().id("engagement-template-notification-test")
+                                .externalArrangementId("engagement-template-notification-test-ext")))));
+
         // When
         subject.updateExistingDataGroupsBatch(batchProductGroupTask,
                 List.of(dataGroupItemTemplateCustom,
@@ -794,6 +843,55 @@ class AccessGroupServiceTest {
                 List.of(baseProductGroupTemplateCustom,
                     baseProductGroupEngagementTemplateCustom,
                     baseProductGroupEngagementTemplateNotification))
+            .block();
+
+        // Then
+        verify(dataGroupIntegrationApi, times(0)).batchUpdateDataItems(any());
+    }
+
+    @Test
+    void updateExistingDataGroupsBatchWhenNoMatchingInDbsIngestionModeReplace() {
+        // Given
+        BatchProductGroupTask batchProductGroupTask = new BatchProductGroupTask();
+        batchProductGroupTask.setIngestionMode(BatchProductIngestionMode.REPLACE);
+        batchProductGroupTask.setBatchProductGroup(new BatchProductGroup().productGroups(
+            List.of(new BaseProductGroup().name("Test product group"))));
+
+        DataGroup unmatchedDataGroup1 = buildDataGroupItem(
+            "Unmatched Data Group 1",
+            "Unmatched Data Group 1",
+            "unmatched-1"
+        );
+        DataGroup unmatchedDataGroup2 = buildDataGroupItem(
+            "Unmatched Data Group 2",
+            "Unmatched Data Group 2",
+            "unmatched-2"
+        );
+
+        BaseProductGroup productGroup1 = buildBaseProductGroup(
+            "Different Product Group 1",
+            "Different Product Group 1",
+            BaseProductGroup.ProductGroupTypeEnum.REPOSITORIES,
+            "different-1"
+        );
+        BaseProductGroup productGroup2 = buildBaseProductGroup(
+            "Different Product Group 2",
+            "Different Product Group 2",
+            BaseProductGroup.ProductGroupTypeEnum.REPOSITORIES,
+            "different-2"
+        );
+
+        when(arrangementsApi.postSearchArrangements(any()))
+            .thenReturn(Mono.just(new ArrangementSearchesListResponse()
+                .arrangementElements(List.of(
+                    new ArrangementItem().id("unmatched-1").externalArrangementId("ext-unmatched-1"),
+                    new ArrangementItem().id("unmatched-2").externalArrangementId("ext-unmatched-2")
+                ))));
+
+        // When
+        subject.updateExistingDataGroupsBatch(batchProductGroupTask,
+                List.of(unmatchedDataGroup1, unmatchedDataGroup2),
+                List.of(productGroup1, productGroup2))
             .block();
 
         // Then
@@ -882,6 +980,19 @@ class AccessGroupServiceTest {
             "Repository Group Engagement Template Notification",
             "Repository Group Engagement Template Notification", BaseProductGroup.ProductGroupTypeEnum.REPOSITORIES,
             "engagement-template-notification");
+
+        when(arrangementsApi.postSearchArrangements(any()))
+            .thenReturn(
+                Mono.just(new ArrangementSearchesListResponse()
+                    .arrangementElements(
+                        List.of(
+                            new ArrangementItem().id("template-custom-test")
+                                .externalArrangementId("template-custom-test-ext"),
+                            new ArrangementItem().id("engagement-template-custom-test")
+                                .externalArrangementId("engagement-template-custom-test-ext"),
+                            new ArrangementItem().id("engagement-template-notification-test")
+                                .externalArrangementId("engagement-template-notification-test-ext")))));
+
         when(dataGroupIntegrationApi.batchUpdateDataItems(any()))
             .thenReturn(
                 Flux.just(new com.backbase.accesscontrol.datagroup.api.integration.v1.model.BatchResponseItemExtended()
@@ -904,22 +1015,22 @@ class AccessGroupServiceTest {
         assertEquals(6, actions.size());
         assertTrue(
             actionForItemIsPresent(actions, com.backbase.accesscontrol.datagroup.api.integration.v1.model.Action.REMOVE,
-                "template-custom-test"));
+                "template-custom-test-ext"));
         assertTrue(
             actionForItemIsPresent(actions, com.backbase.accesscontrol.datagroup.api.integration.v1.model.Action.REMOVE,
-                "engagement-template-custom-test"));
+                "engagement-template-custom-test-ext"));
         assertTrue(
             actionForItemIsPresent(actions, com.backbase.accesscontrol.datagroup.api.integration.v1.model.Action.REMOVE,
-                "engagement-template-notification-test"));
+                "engagement-template-notification-test-ext"));
         assertTrue(
             actionForItemIsPresent(actions, com.backbase.accesscontrol.datagroup.api.integration.v1.model.Action.ADD,
-                "template-custom"));
+                "template-custom-ext"));
         assertTrue(
             actionForItemIsPresent(actions, com.backbase.accesscontrol.datagroup.api.integration.v1.model.Action.ADD,
-                "engagement-template-custom"));
+                "engagement-template-custom-ext"));
         assertTrue(
             actionForItemIsPresent(actions, com.backbase.accesscontrol.datagroup.api.integration.v1.model.Action.ADD,
-                "engagement-template-notification"));
+                "engagement-template-notification-ext"));
     }
 
     @Test
@@ -943,6 +1054,15 @@ class AccessGroupServiceTest {
             "rep desc", BaseProductGroup.ProductGroupTypeEnum.REPOSITORIES,
             "repository-dg-item2");
 
+        when(arrangementsApi.postSearchArrangements(any()))
+            .thenReturn(
+                Mono.just(new ArrangementSearchesListResponse()
+                    .arrangementElements(
+                        List.of(
+                            new ArrangementItem().id("custom-dg-item1").externalArrangementId("custom-dg-item1-ext"),
+                            new ArrangementItem().id("custom-dg-item2").externalArrangementId("custom-dg-item2-ext"),
+                            new ArrangementItem().id("repository-dg-item1").externalArrangementId("repository-dg-item1-ext")))));
+
         when(dataGroupIntegrationApi.batchUpdateDataItems(any()))
             .thenReturn(
                 Flux.just(new com.backbase.accesscontrol.datagroup.api.integration.v1.model.BatchResponseItemExtended()
@@ -962,23 +1082,23 @@ class AccessGroupServiceTest {
 
         assertTrue(
             actionForItemIsPresent(actions, com.backbase.accesscontrol.datagroup.api.integration.v1.model.Action.ADD,
-                "repository-dg-item2"));
+                "repository-dg-item2-ext"));
         assertTrue(
             actionForItemIsPresent(actions, com.backbase.accesscontrol.datagroup.api.integration.v1.model.Action.REMOVE,
-                "repository-dg-item1"));
+                "repository-dg-item1-ext"));
         // the following assertions is to test if for some reason "custom-dg-item1" and "custom-dg-item2" ended up paired with "repository-dg-item*" ;)
         assertFalse(
             actionForItemIsPresent(actions, com.backbase.accesscontrol.datagroup.api.integration.v1.model.Action.REMOVE,
-                "custom-dg-item1"));
+                "custom-dg-item1-ext"));
         assertFalse(
             actionForItemIsPresent(actions, com.backbase.accesscontrol.datagroup.api.integration.v1.model.Action.REMOVE,
-                "custom-dg-item2"));
+                "custom-dg-item2-ext"));
         assertFalse(
             actionForItemIsPresent(actions, com.backbase.accesscontrol.datagroup.api.integration.v1.model.Action.ADD,
-                "custom-dg-item1"));
+                "custom-dg-item1-ext"));
         assertFalse(
             actionForItemIsPresent(actions, com.backbase.accesscontrol.datagroup.api.integration.v1.model.Action.ADD,
-                "custom-dg-item2"));
+                "custom-dg-item2-ext"));
     }
 
     @Test
@@ -997,6 +1117,13 @@ class AccessGroupServiceTest {
             .productGroupType(ProductGroupTypeEnum.ARRANGEMENTS)
             .addCurrentAccountsItem(new CurrentAccount().internalId("debitAccountInId").name("arrangement1")
                 .externalId("debitAccountExId"));
+
+        when(arrangementsApi.postSearchArrangements(any()))
+            .thenReturn(
+                Mono.just(new ArrangementSearchesListResponse()
+                    .arrangementElements(
+                        List.of(
+                            new ArrangementItem().id("debitAccountInId").externalArrangementId("debitAccountExId")))));
 
         subject.updateExistingDataGroupsBatch(batchProductGroupTask,
                 List.of(existingDGroup),
@@ -1017,6 +1144,13 @@ class AccessGroupServiceTest {
 
         DataGroup existingDGroup = new DataGroup().id("debitAccountInId1").name("arrangement1")
             .addItemsItem("debitAccountExId1").serviceAgreementId("saInId");
+
+        when(arrangementsApi.postSearchArrangements(any()))
+            .thenReturn(
+                Mono.just(new ArrangementSearchesListResponse()
+                    .arrangementElements(
+                        List.of(
+                            new ArrangementItem().id("debitAccountExId1").externalArrangementId("debitAccountExId1")))));
 
         when(dataGroupIntegrationApi.batchUpdateDataItems(any()))
             .thenReturn(
@@ -1041,7 +1175,7 @@ class AccessGroupServiceTest {
         assertEquals(2, actions.size());
         assertTrue(
             actionForItemIsPresent(actions, com.backbase.accesscontrol.datagroup.api.integration.v1.model.Action.ADD,
-                "debitAccountInId2"));
+                "debitAccountExId2"));
         assertTrue(
             actionForItemIsPresent(actions, com.backbase.accesscontrol.datagroup.api.integration.v1.model.Action.REMOVE,
                 "debitAccountExId1"));
@@ -1062,6 +1196,14 @@ class AccessGroupServiceTest {
         BaseProductGroup upsertProductGroupCustom = buildBaseProductGroup("Custom data group item",
             "custom desc", ProductGroupTypeEnum.CUSTOM,
             "custom-dg-item2");
+
+        when(arrangementsApi.postSearchArrangements(any()))
+            .thenReturn(
+                Mono.just(new ArrangementSearchesListResponse()
+                    .arrangementElements(
+                        List.of(
+                            new ArrangementItem().id("custom-dg-item1").externalArrangementId("custom-dg-item1-ext")))));
+
         when(dataGroupIntegrationApi.batchUpdateDataItems(any())).thenReturn(
             Flux.error(WebClientResponseException.create(500, "Internal error", null, null, null, null)));
 
@@ -1102,6 +1244,7 @@ class AccessGroupServiceTest {
 
         // Then
         verify(dataGroupIntegrationApi, times(0)).batchUpdateDataItems(any());
+        verifyNoInteractions(arrangementsApi);
     }
 
 
@@ -1440,7 +1583,7 @@ class AccessGroupServiceTest {
         productGroup.setDescription(description);
         productGroup.setProductGroupType(productGroupTypeEnum);
         productGroup.setCustomDataGroupItems(Arrays.stream(dataGroupItemId)
-            .map(dgi -> new CustomDataGroupItem().internalId(dgi).externalId(dgi)).toList());
+            .map(dgi -> new CustomDataGroupItem().internalId(dgi).externalId(dgi + "-ext")).toList());
         return productGroup;
     }
 

--- a/stream-access-control/access-control-core/src/test/java/com/backbase/stream/service/AccessGroupServiceUpdateFunctionGroupsTest.java
+++ b/stream-access-control/access-control-core/src/test/java/com/backbase/stream/service/AccessGroupServiceUpdateFunctionGroupsTest.java
@@ -19,6 +19,7 @@ import com.backbase.accesscontrol.functiongroup.api.service.v1.model.ResultId;
 import com.backbase.accesscontrol.permissioncheck.api.service.v1.PermissionCheckApi;
 import com.backbase.accesscontrol.serviceagreement.api.service.v1.ServiceAgreementApi;
 import com.backbase.accesscontrol.usercontext.api.service.v1.UserContextApi;
+import com.backbase.dbs.arrangement.api.service.v3.ArrangementsApi;
 import com.backbase.dbs.user.api.service.v2.UserManagementApi;
 import com.backbase.stream.configuration.AccessControlConfigurationProperties;
 import com.backbase.stream.configuration.DeletionProperties;
@@ -34,7 +35,6 @@ import com.backbase.stream.worker.model.StreamTask;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -59,6 +59,8 @@ class AccessGroupServiceUpdateFunctionGroupsTest {
 
     @Mock
     private UserManagementApi usersApi;
+    @Mock
+    private ArrangementsApi arrangementsApi;
     @Mock
     private PermissionCheckApi permissionCheckServiceApi;
     @Mock


### PR DESCRIPTION
## Description

 Fix update data group items request to access-control (use externalDataItemIds instead of internal)

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
  
  Add N/A to the task if they are not relevant to the current PR(validation will be skipped). 
  e.g. [ ] My changes are adequately tested ~ N/A
-->

 - [x] I made sure, I read [CONTRIBUTING.md](CONTRIBUTING.md) to put right branch prefix as per my need.
 - [x] I made sure to update [CHANGELOG.md](CHANGELOG.md).
 - [ ] I made sure to update [Stream Wiki](https://github.com/Backbase/stream-services/wiki)(only valid in case of new stream module or architecture changes).
 - [x] My changes are adequately tested.
 - [x] I made sure all the SonarCloud Quality Gate are passed.
