### PR TITLE
fix: retrieve plan if not available in map (NOJIRA)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [10.6.1]
+### Changed
+- Updated plan manager ingestion logic to attempt to retrieve plans if they don't exist in the pre-filled map.
+
 ## [10.6.0]
 ### Added
 - Added withdrawals to investment service ingestion

--- a/stream-plan-manager/plan-manager-core/src/main/java/com/backbase/streams/tailoredvalue/PlansService.java
+++ b/stream-plan-manager/plan-manager-core/src/main/java/com/backbase/streams/tailoredvalue/PlansService.java
@@ -49,24 +49,44 @@ public class PlansService {
     }
 
     public Mono<Void> updateUserPlan(String internalUserId, UserPlanUpdateRequestBody userPlanUpdateRequestBody, String planName) {
+        return resolvePlanId(planName)
+                .flatMap(planId -> {
+                    userPlanUpdateRequestBody.setId(planId);
+                    log.info("Started ingestion of plans {} for user {}", planId, internalUserId);
+                    return userPlansApi.updateUserPlan(internalUserId, userPlanUpdateRequestBody)
+                            .doOnNext(response -> log.info("Plan updated: {}", response))
+                            .onErrorResume(throwable -> {
+                                log.error("Error updating plan", throwable);
+                                return Mono.error(new PlanManagerException(throwable, "Error updating plan"));
+                            })
+                            .then();
+                });
+    }
 
-        if (!plansMap.containsKey(planName)) {
-            log.warn("No PlanId found for planName = " + planName);
-            return Mono.error(new PlanManagerException("No PlanId found for planName = " + planName));
+    private Mono<String> resolvePlanId(String planName) {
+        if (plansMap.containsKey(planName)) {
+            return Mono.just(plansMap.get(planName));
         }
-        // Set planId
-        userPlanUpdateRequestBody.setId(plansMap.get(planName));
-        log.info("Started ingestion of plans {} for user {}",
-                userPlanUpdateRequestBody.getId(), internalUserId);
-        return userPlansApi.updateUserPlan(internalUserId, userPlanUpdateRequestBody)
-                .map(userPlanUpdateResponseBody -> {
-                    log.info("Plan updated: {}", userPlanUpdateResponseBody.toString());
-                    return Mono.empty();
-                })
-                .onErrorResume(throwable -> {
-                    log.error("Error updating plan", throwable);
-                    return Mono.error(new PlanManagerException(throwable, "Error updating plan"));
-                }).then();
+        return plansApi.getPlans(null, null, planName)
+                .flatMap(responseBody -> {
+                    if (responseBody == null || responseBody.getPlans() == null || responseBody.getPlans().isEmpty()) {
+                        return planIdNotFound(planName);
+                    }
+                    return responseBody.getPlans().stream()
+                            .filter(plan -> planName.equals(plan.getName()))
+                            .findFirst()
+                            .map(plan -> {
+                                plansMap.put(plan.getName(), plan.getId());
+                                return plan.getId();
+                            })
+                            .map(Mono::just)
+                            .orElseGet(() -> planIdNotFound(planName));
+                });
+    }
+
+    private Mono<String> planIdNotFound(String planName) {
+        log.warn("No PlanId found for planName = {}", planName);
+        return Mono.error(new PlanManagerException("No PlanId found for planName = " + planName));
     }
 
     private void processPlans(PlansGetResponseBody responseBody) {

--- a/stream-plan-manager/plan-manager-core/src/test/java/com/backbase/streams/tailoredvalue/plan/PlanServiceTest.java
+++ b/stream-plan-manager/plan-manager-core/src/test/java/com/backbase/streams/tailoredvalue/plan/PlanServiceTest.java
@@ -2,6 +2,9 @@ package com.backbase.streams.tailoredvalue.plan;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -92,6 +95,74 @@ class PlanServiceTest {
     }
 
     @Test
+    void testUpdateUserPlan_whenPlanNotInMap_resolvesPlanIdFromApi() {
+        //Given
+        UserPlanUpdateRequestBody reqBody = createUserPlanUpdateRequestBody();
+        when(plansApi.getPlans(isNull(), isNull(), eq(PLAN_NAME)))
+                .thenReturn(Mono.just(createPlansGetResponseBody(PLAN_ID, PLAN_NAME)));
+        when(userPlansApi.updateUserPlan(INTERNAL_USER_ID, reqBody))
+                .thenReturn(Mono.just(new UserPlanUpdateResponseBody()));
+
+        //When
+        plansService.updateUserPlan(INTERNAL_USER_ID, reqBody, PLAN_NAME).block();
+
+        //Then
+        assertEquals(PLAN_ID, reqBody.getId());
+        assertEquals(PLAN_ID, plansService.getPlansMap().get(PLAN_NAME));
+        verify(plansApi).getPlans(isNull(), isNull(), eq(PLAN_NAME));
+        verify(userPlansApi).updateUserPlan(INTERNAL_USER_ID, reqBody);
+    }
+
+    @Test
+    void testUpdateUserPlan_whenPlanNotInMap_andApiReturnsEmptyPlans_throwsException() {
+        //Given
+        UserPlanUpdateRequestBody reqBody = createUserPlanUpdateRequestBody();
+        PlansGetResponseBody emptyResponse = new PlansGetResponseBody();
+        emptyResponse.setPlans(List.of());
+        when(plansApi.getPlans(isNull(), isNull(), eq(PLAN_NAME)))
+                .thenReturn(Mono.just(emptyResponse));
+
+        //When
+        Mono<Void> mono = plansService.updateUserPlan(INTERNAL_USER_ID, reqBody, PLAN_NAME);
+
+        //Then
+        Assertions.assertThrows(PlanManagerException.class, mono::block);
+        verify(userPlansApi, never()).updateUserPlan(any(), any());
+    }
+
+    @Test
+    void testUpdateUserPlan_whenPlanNotInMap_andApiReturnsNullPlans_throwsException() {
+        //Given
+        UserPlanUpdateRequestBody reqBody = createUserPlanUpdateRequestBody();
+        PlansGetResponseBody responseWithNullPlans = new PlansGetResponseBody();
+        responseWithNullPlans.setPlans(null);
+        when(plansApi.getPlans(isNull(), isNull(), eq(PLAN_NAME)))
+                .thenReturn(Mono.just(responseWithNullPlans));
+
+        //When
+        Mono<Void> mono = plansService.updateUserPlan(INTERNAL_USER_ID, reqBody, PLAN_NAME);
+
+        //Then
+        Assertions.assertThrows(PlanManagerException.class, mono::block);
+        verify(userPlansApi, never()).updateUserPlan(any(), any());
+    }
+
+    @Test
+    void testUpdateUserPlan_whenPlanNotInMap_andApiReturnsDifferentPlanName_throwsException() {
+        //Given
+        UserPlanUpdateRequestBody reqBody = createUserPlanUpdateRequestBody();
+        when(plansApi.getPlans(isNull(), isNull(), eq(PLAN_NAME)))
+                .thenReturn(Mono.just(createPlansGetResponseBody("other-plan-id", "other-plan-name")));
+
+        //When
+        Mono<Void> mono = plansService.updateUserPlan(INTERNAL_USER_ID, reqBody, PLAN_NAME);
+
+        //Then
+        Assertions.assertThrows(PlanManagerException.class, mono::block);
+        verify(userPlansApi, never()).updateUserPlan(any(), any());
+    }
+
+    @Test
     void testExecuteTask_whenPlansPropertiesIsEnabled_andUserPlansApi_throws_Exception() {
         //Given
         when(plansProperties.isEnabled()).thenReturn(true);
@@ -110,9 +181,14 @@ class PlanServiceTest {
 
 
     private void mockPlansApi() {
+        when(plansApi.getPlans(any(), any(), any()))
+                .thenAnswer(invocation -> Mono.just(createPlansGetResponseBody(PLAN_ID, PLAN_NAME)));
+    }
+
+    private PlansGetResponseBody createPlansGetResponseBody(String planId, String planName) {
         PlansGetResponseBody plansGetResponseBody = new PlansGetResponseBody();
-        plansGetResponseBody.setPlans(List.of(new Plan().id(PLAN_ID).name(PLAN_NAME)));
-        when(plansApi.getPlans(any(), any(), any())).thenAnswer(invocation -> Mono.just(plansGetResponseBody));
+        plansGetResponseBody.setPlans(List.of(new Plan().id(planId).name(planName)));
+        return plansGetResponseBody;
     }
 
     private UserPlanUpdateRequestBody createUserPlanUpdateRequestBody() {


### PR DESCRIPTION
## Description

Update plan manager ingestion to try to retrieve plan if it doesn't exist in the `@PostConstruct` map.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
  
  Add N/A to the task if they are not relevant to the current PR(validation will be skipped). 
  e.g. [ ] My changes are adequately tested ~ N/A
-->

 - [ ] I made sure, I read [CONTRIBUTING.md](CONTRIBUTING.md) to put right branch prefix as per my need.
 - [ ] I made sure to update [CHANGELOG.md](CHANGELOG.md).
 - [ ] I made sure to update [Stream Wiki](https://github.com/Backbase/stream-services/wiki)(only valid in case of new stream module or architecture changes).
 - [ ] My changes are adequately tested.
 - [ ] I made sure all the SonarCloud Quality Gate are passed.
