### PR TITLE
Investment/fix content entry failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,12 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
-## [10.6.2]
+## [10.7.1]
+### Changed
+- Updated stream-investment to be able to seed extra_data to investment portfolio
+- fix content entry seeding issue
+
+## [10.7.0]
 ### Changed
 - Updated stream-investment to be able to seed to investment caboose
 

--- a/stream-investment/investment-core/src/main/java/com/backbase/stream/configuration/InvestmentRestServiceApiConfiguration.java
+++ b/stream-investment/investment-core/src/main/java/com/backbase/stream/configuration/InvestmentRestServiceApiConfiguration.java
@@ -57,6 +57,14 @@ public class InvestmentRestServiceApiConfiguration {
         return apiClient;
     }
 
+    /**
+     * Dedicated {@link ObjectMapper} for investment RestTemplate calls.
+     *
+     * <p>Uses {@link Include#NON_EMPTY} to omit blank optional fields in multipart requests.
+     * JSON content entry create serialises payloads to {@code byte[]} explicitly in
+     * {@link InvestmentRestNewsContentService} to avoid {@code RestTemplate} {@code ObjectNode}
+     * serialisation issues.
+     */
     @Bean
     @Qualifier("restInvestmentObjectMapper")
     public ObjectMapper restInvestmentObjectMapper(ObjectMapper legacyObjectMapper) {
@@ -80,12 +88,17 @@ public class InvestmentRestServiceApiConfiguration {
         return new com.backbase.investment.api.service.sync.v1.AssetUniverseApi(restInvestmentApiClient);
     }
 
+    /**
+     * RestTemplate-based news content service. Requires {@code restInvestmentObjectMapper} for
+     * manual JSON serialisation in {@link InvestmentRestNewsContentService}.
+     */
     @Bean
     @Primary
     public InvestmentRestNewsContentService investmentNewsContentService(
         @Qualifier("restContentApi") ContentApi restContentApi,
-        @Qualifier("restInvestmentApiClient") com.backbase.investment.api.service.sync.ApiClient restInvestmentApiClient) {
-        return new InvestmentRestNewsContentService(restContentApi, restInvestmentApiClient);
+        @Qualifier("restInvestmentApiClient") com.backbase.investment.api.service.sync.ApiClient restInvestmentApiClient,
+        @Qualifier("restInvestmentObjectMapper") ObjectMapper restInvestmentObjectMapper) {
+        return new InvestmentRestNewsContentService(restContentApi, restInvestmentApiClient, restInvestmentObjectMapper);
     }
 
     @Bean

--- a/stream-investment/investment-core/src/main/java/com/backbase/stream/configuration/InvestmentRestServiceApiConfiguration.java
+++ b/stream-investment/investment-core/src/main/java/com/backbase/stream/configuration/InvestmentRestServiceApiConfiguration.java
@@ -57,14 +57,6 @@ public class InvestmentRestServiceApiConfiguration {
         return apiClient;
     }
 
-    /**
-     * Dedicated {@link ObjectMapper} for investment RestTemplate calls.
-     *
-     * <p>Uses {@link Include#NON_EMPTY} to omit blank optional fields in multipart requests.
-     * JSON content entry create serialises payloads to {@code byte[]} explicitly in
-     * {@link InvestmentRestNewsContentService} to avoid {@code RestTemplate} {@code ObjectNode}
-     * serialisation issues.
-     */
     @Bean
     @Qualifier("restInvestmentObjectMapper")
     public ObjectMapper restInvestmentObjectMapper(ObjectMapper legacyObjectMapper) {
@@ -88,10 +80,6 @@ public class InvestmentRestServiceApiConfiguration {
         return new com.backbase.investment.api.service.sync.v1.AssetUniverseApi(restInvestmentApiClient);
     }
 
-    /**
-     * RestTemplate-based news content service. Requires {@code restInvestmentObjectMapper} for
-     * manual JSON serialisation in {@link InvestmentRestNewsContentService}.
-     */
     @Bean
     @Primary
     public InvestmentRestNewsContentService investmentNewsContentService(

--- a/stream-investment/investment-core/src/main/java/com/backbase/stream/investment/InvestmentArrangement.java
+++ b/stream-investment/investment-core/src/main/java/com/backbase/stream/investment/InvestmentArrangement.java
@@ -2,6 +2,7 @@ package com.backbase.stream.investment;
 
 import java.math.BigDecimal;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import lombok.Builder;
 import lombok.Data;
@@ -20,6 +21,7 @@ public class InvestmentArrangement {
     private String productPortfolioName;
     private BigDecimal initialCash;
     private BigDecimal withdrawalAmount;
+    private Map<String, String> extraData;
 
     private UUID investmentProductId;
     private List<String> legalEntityIds;

--- a/stream-investment/investment-core/src/main/java/com/backbase/stream/investment/service/InvestmentPortfolioService.java
+++ b/stream-investment/investment-core/src/main/java/com/backbase/stream/investment/service/InvestmentPortfolioService.java
@@ -187,10 +187,11 @@ public class InvestmentPortfolioService {
             .name(investmentArrangement.getName())
             .clients(associatedClients)
             .status(StatusA3dEnum.ACTIVE)
-            .activated(OffsetDateTime.now().minusMonths(config.getPortfolio().getActivationPastMonths()));
+            .activated(OffsetDateTime.now().minusMonths(config.getPortfolio().getActivationPastMonths()))
+            .extraData(investmentArrangement.getExtraData());
 
-        log.debug("Attempting to patch existing portfolio: uuid={}, externalId={}",
-            uuid, investmentArrangement.getExternalId());
+        log.debug("Attempting to patch existing portfolio: uuid={}, externalId={}, extraData={}",
+            uuid, investmentArrangement.getExternalId(), investmentArrangement.getExtraData());
 
         return portfolioApi.patchPortfolio(uuid, null, null, null, patchedPortfolioUpdateRequest)
             .doOnSuccess(updated -> {
@@ -237,7 +238,11 @@ public class InvestmentPortfolioService {
             .currency(Optional.ofNullable(investmentArrangement.getCurrency())
                 .orElse(config.getPortfolio().getDefaultCurrency()))
             .status(StatusA3dEnum.ACTIVE)
-            .activated(OffsetDateTime.now().minusMonths(config.getPortfolio().getActivationPastMonths()));
+            .activated(OffsetDateTime.now().minusMonths(config.getPortfolio().getActivationPastMonths()))
+            .extraData(investmentArrangement.getExtraData());
+
+        log.debug("Creating investment portfolio: externalId={}, name={}, extraData={}",
+            investmentArrangement.getExternalId(), investmentArrangement.getName(), investmentArrangement.getExtraData());
 
         return portfolioApi.createPortfolio(request, null, null, null)
             .doOnSuccess(created -> log.info(

--- a/stream-investment/investment-core/src/main/java/com/backbase/stream/investment/service/resttemplate/InvestmentRestNewsContentService.java
+++ b/stream-investment/investment-core/src/main/java/com/backbase/stream/investment/service/resttemplate/InvestmentRestNewsContentService.java
@@ -1,5 +1,7 @@
 package com.backbase.stream.investment.service.resttemplate;
 
+import static com.backbase.investment.api.service.sync.v1.model.EntryCreateUpdateRequest.JSON_PROPERTY_ASSETS;
+import static com.backbase.investment.api.service.sync.v1.model.EntryCreateUpdateRequest.JSON_PROPERTY_THUMBNAIL;
 import static com.backbase.stream.investment.service.resttemplate.InvestmentRestAssetUniverseService.getFileNameForLog;
 
 import com.backbase.investment.api.service.sync.ApiClient;
@@ -9,14 +11,19 @@ import com.backbase.investment.api.service.sync.v1.model.EntryCreateUpdate;
 import com.backbase.investment.api.service.sync.v1.model.EntryCreateUpdateRequest;
 import com.backbase.investment.api.service.sync.v1.model.EntryTagRequest;
 import com.backbase.investment.api.service.sync.v1.model.PatchedEntryTagRequest;
+import com.backbase.investment.api.service.sync.v1.model.RelatedAssetSerializerWithAssetCategoriesRequest;
 import com.backbase.stream.investment.model.MarketNewsEntry;
 import com.backbase.stream.investment.model.ContentTag;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.Objects;
 import java.util.Set;
-import java.util.UUID;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -29,26 +36,29 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestClientException;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 /**
- * REST client service for upserting market news content and tags via the Investment Content API.
+ * RestTemplate-based service for market news content and tags against the Investment service
+ * {@code /service-api/v2/content/} endpoints.
  *
- * <p>This service manages:
+ * <p>This service avoids serialisation issues present in the auto-generated
+ * {@code ContentApi#createContentEntry} client introduced with investment-service-api 1.6.x:
  * <ul>
- *   <li>Market news tag creation and updates</li>
- *   <li>Market news content entry creation (skips duplicates by title)</li>
- *   <li>Thumbnail attachment for newly created content entries</li>
+ *   <li>explicit {@code thumbnail: null} is rejected by the investment API</li>
+ *   <li>empty {@code assets} arrays must be present on create</li>
+ *   <li>multipart create does not reliably transmit JSON array fields</li>
+ *   <li>{@code ObjectNode} request bodies are not always serialised by {@code RestTemplate}</li>
  * </ul>
  *
- * <p>Design notes (see CODING_RULES_COPILOT.md):
- * <ul>
- *   <li>No direct manipulation of generated API classes beyond construction and mapping</li>
- *   <li>Side-effecting operations are logged at info (create) or debug (patch) levels</li>
- *   <li>Individual entry failures are logged and swallowed so batch processing continues</li>
- *   <li>All reactive operations include proper success and error handlers for observability</li>
- * </ul>
+ * <p>Content entry create uses JSON {@code POST /service-api/v2/content/entries/} via
+ * {@link ApiClient#invokeAPI}; optional thumbnail upload uses multipart
+ * {@code PATCH /service-api/v2/content/entries/{uuid}/}. Mapping from the stream
+ * {@link MarketNewsEntry} model is handled by {@link ContentMapper}.
+ *
+ * @see InvestmentRestDocumentContentService
  */
 @Slf4j
 @RequiredArgsConstructor
@@ -56,17 +66,23 @@ public class InvestmentRestNewsContentService {
 
     /** Maximum number of content or tag entries retrieved in a single list call. */
     public static final int CONTENT_RETRIEVE_LIMIT = 100;
+
+    private static final String CREATE_CONTENT_ENTRY_PATH = "/service-api/v2/content/entries/";
+    private static final String PATCH_CONTENT_ENTRY_PATH = "/service-api/v2/content/entries/{uuid}/";
+
+    private static final String[] JSON_CONTENT_TYPES = {"application/json"};
+    private static final String[] MULTIPART_CONTENT_TYPES = {"multipart/form-data"};
+
     private final ContentApi contentApi;
     private final ApiClient apiClient;
+    private final ObjectMapper objectMapper;
     private final ContentMapper contentMapper = Mappers.getMapper(ContentMapper.class);
 
     /**
-     * Upserts a batch of content tags. For each tag, checks whether a tag with the same code already exists.
-     * If found, patches it; otherwise creates a new tag. Tags with blank code or value are skipped.
-     * Individual failures are logged and swallowed so remaining tags continue processing.
+     * Creates or updates market news tags via {@code ContentApi} entry-tag endpoints.
      *
-     * @param tagEntries list of tags to upsert
-     * @return Mono that completes when all tags have been processed
+     * @param tagEntries tags to upsert
+     * @return {@link Mono} that completes when all tags have been processed
      */
     public Mono<Void> upsertTags(List<ContentTag> tagEntries) {
         log.info("Starting tag upsert batch operation: totalEntriesSubmitted={}", tagEntries.size());
@@ -85,19 +101,31 @@ public class InvestmentRestNewsContentService {
     }
 
     /**
-     * Upserts a single tag entry using the ContentApi tag endpoints. Implementation follows the upsert pattern:
-     * <ol>
-     *   <li>List existing tag entries to check if the tag code already exists</li>
-     *   <li>If tag exists, patch it with the new value</li>
-     *   <li>If not found, create a new tag entry</li>
-     * </ol>
+     * Creates new market news content entries that are not already present in the investment service.
      *
-     * @param marketNewsTag the tag to upsert
-     * @return Mono that completes with the tag when processed, or empty if validation fails or an error occurs
+     * @param contentEntries news entries to upsert
+     * @return {@link Mono} that completes when all new entries have been processed
      */
+    public Mono<Void> upsertContent(List<MarketNewsEntry> contentEntries) {
+        log.info("Starting content upsert batch operation: totalEntriesSubmitted={}", contentEntries.size());
+        log.debug("Content upsert batch details: entries={}", contentEntries);
+
+        return findEntriesNewContent(contentEntries)
+            .flatMap(this::upsertSingleEntry)
+            .count()
+            .doOnNext(entriesCreated -> log.info(
+                "Content upsert batch completed successfully: totalEntriesSubmitted={}, entriesCreated={}",
+                contentEntries.size(), entriesCreated))
+            .doOnError(error -> log.error(
+                "Content upsert batch failed: totalEntriesSubmitted={}, errorType={}, errorMessage={}",
+                contentEntries.size(), error.getClass().getSimpleName(), error.getMessage(), error))
+            .then();
+    }
+
     private Mono<ContentTag> upsertSingleTag(ContentTag marketNewsTag) {
         log.debug("Processing tag: code='{}', value='{}'", marketNewsTag.getCode(), marketNewsTag.getValue());
 
+        // Validation
         if (marketNewsTag.getCode() == null || marketNewsTag.getCode().isBlank()) {
             log.warn("Skipping tag with empty code: value='{}'", marketNewsTag.getValue());
             return Mono.empty();
@@ -111,8 +139,8 @@ public class InvestmentRestNewsContentService {
         log.debug("Checking if tag entry exists: code='{}', value='{}'",
             marketNewsTag.getCode(), marketNewsTag.getValue());
 
-        return Mono.fromCallable(() ->
-                contentApi.contentEntryTagList(CONTENT_RETRIEVE_LIMIT, 0))
+        // Check if tag entry already exists
+        return Mono.fromCallable(() -> contentApi.contentEntryTagList(CONTENT_RETRIEVE_LIMIT, 0))
             .map(paginatedList -> paginatedList.getResults().stream()
                 .filter(Objects::nonNull)
                 .filter(entry -> marketNewsTag.getCode().equals(entry.getCode()))
@@ -138,12 +166,6 @@ public class InvestmentRestNewsContentService {
             });
     }
 
-    /**
-     * Creates a new tag entry using the ContentApi.
-     *
-     * @param contentTag the tag to create an entry for
-     * @return Mono of the created tag
-     */
     private Mono<ContentTag> createTagEntry(ContentTag contentTag) {
         EntryTagRequest request = new EntryTagRequest()
             .code(contentTag.getCode())
@@ -160,12 +182,6 @@ public class InvestmentRestNewsContentService {
             .thenReturn(contentTag);
     }
 
-    /**
-     * Patches an existing tag entry with updated values.
-     *
-     * @param contentTag the tag with updated values to patch
-     * @return Mono of the patched tag
-     */
     private Mono<ContentTag> patchTagEntry(ContentTag contentTag) {
         PatchedEntryTagRequest request = new PatchedEntryTagRequest()
             .code(contentTag.getCode())
@@ -182,46 +198,11 @@ public class InvestmentRestNewsContentService {
             .thenReturn(contentTag);
     }
 
-    /**
-     * Creates new market news content entries. Entries whose title matches an existing entry are skipped.
-     * Individual failures are logged and swallowed so remaining entries continue processing.
-     *
-     * @param contentEntries list of content entries to create
-     * @return Mono that completes when all eligible entries have been processed
-     */
-    public Mono<Void> upsertContent(List<MarketNewsEntry> contentEntries) {
-        log.info("Starting content upsert batch operation: totalEntriesSubmitted={}", contentEntries.size());
-        log.debug("Content upsert batch details: entries={}", contentEntries);
-
-        return findEntriesNewContent(contentEntries)
-            .flatMap(this::upsertSingleEntry)
-            .count()
-            .doOnNext(entriesCreated -> log.info(
-                "Content upsert batch completed successfully: totalEntriesSubmitted={}, entriesCreated={}",
-                contentEntries.size(), entriesCreated))
-            .doOnError(error -> log.error(
-                "Content upsert batch failed: totalEntriesSubmitted={}, errorType={}, errorMessage={}",
-                contentEntries.size(), error.getClass().getSimpleName(), error.getMessage(), error))
-            .then();
-    }
-
-    /**
-     * Creates a single market news content entry and optionally attaches a thumbnail.
-     * Callers must supply entries that have already been filtered as non-duplicates.
-     * Errors are logged and swallowed to allow processing of remaining entries.
-     *
-     * @param request the content entry to create
-     * @return Mono that completes with the created entry, or empty if creation fails
-     */
     private Mono<EntryCreateUpdate> upsertSingleEntry(MarketNewsEntry request) {
         log.debug("Creating content entry: title='{}', hasThumbnail={}", request.getTitle(),
             request.getThumbnailResource() != null);
 
-        EntryCreateUpdateRequest createUpdateRequest = contentMapper.map(request);
-        log.debug("Content entry request mapped: title='{}', request={}", request.getTitle(), createUpdateRequest);
-
-        return Mono.defer(() -> Mono.just(contentApi.createContentEntry(createUpdateRequest)))
-            .flatMap(entry -> addThumbnail(entry, request.getThumbnailResource()))
+        return Mono.defer(() -> Mono.fromCallable(() -> invokeCreateContentEntry(request)))
             .doOnSuccess(created -> log.info(
                 "Content entry created successfully: title='{}', uuid={}, thumbnailAttached={}",
                 request.getTitle(), created.getUuid(), request.getThumbnailResource() != null))
@@ -232,12 +213,96 @@ public class InvestmentRestNewsContentService {
     }
 
     /**
-     * Filters the supplied content entries to those not already present in the system.
-     * An entry is considered a duplicate when its title contains an existing entry title.
+     * Creates a content entry and optionally attaches a thumbnail file.
      *
-     * @param contentEntries entries to filter
-     * @return Flux of entries that should be created
+     * @throws RestClientException if the investment service returns an error
      */
+    private EntryCreateUpdate invokeCreateContentEntry(MarketNewsEntry entry) throws RestClientException {
+        EntryCreateUpdateRequest request = contentMapper.map(entry);
+        EntryCreateUpdate created = invokeCreate(request);
+
+        Resource thumbnail = entry.getThumbnailResource();
+        if (thumbnail != null) {
+            return invokePatchThumbnail(created.getUuid(), thumbnail);
+        }
+        return created;
+    }
+
+    private EntryCreateUpdate invokeCreate(EntryCreateUpdateRequest request) throws RestClientException {
+        byte[] bodyBytes = buildCreateRequestBodyBytes(request);
+        log.debug("Creating content entry JSON payload: title='{}'", request.getTitle());
+
+        final List<MediaType> accept = apiClient.selectHeaderAccept(new String[]{"application/json"});
+        final MediaType contentType = apiClient.selectHeaderContentType(JSON_CONTENT_TYPES);
+        ParameterizedTypeReference<EntryCreateUpdate> returnType = new ParameterizedTypeReference<>() {
+        };
+
+        return apiClient.invokeAPI(
+                CREATE_CONTENT_ENTRY_PATH,
+                HttpMethod.POST,
+                Collections.emptyMap(),
+                new LinkedMultiValueMap<>(),
+                bodyBytes,
+                new HttpHeaders(),
+                new LinkedMultiValueMap<>(),
+                new LinkedMultiValueMap<>(),
+                accept,
+                contentType,
+                new String[]{},
+                returnType)
+            .getBody();
+    }
+
+    private EntryCreateUpdate invokePatchThumbnail(UUID uuid, Resource thumbnail) throws RestClientException {
+        final Map<String, Object> uriVariables = new HashMap<>();
+        uriVariables.put("uuid", uuid.toString());
+
+        final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<>();
+        log.debug("Patching content entry thumbnail: uuid={}, thumbnailFile='{}'",
+            uuid, getFileNameForLog(thumbnail));
+        formParams.add(JSON_PROPERTY_THUMBNAIL, thumbnail);
+
+        final List<MediaType> accept = apiClient.selectHeaderAccept(new String[]{"application/json"});
+        final MediaType contentType = apiClient.selectHeaderContentType(MULTIPART_CONTENT_TYPES);
+        ParameterizedTypeReference<EntryCreateUpdate> returnType = new ParameterizedTypeReference<>() {
+        };
+
+        return apiClient.invokeAPI(
+                PATCH_CONTENT_ENTRY_PATH,
+                HttpMethod.PATCH,
+                uriVariables,
+                new LinkedMultiValueMap<>(),
+                null,
+                new HttpHeaders(),
+                new LinkedMultiValueMap<>(),
+                formParams,
+                accept,
+                contentType,
+                new String[]{},
+                returnType)
+            .getBody();
+    }
+
+    /**
+     * Builds JSON request bytes for content entry create.
+     *
+     * <p>{@code thumbnail} is omitted (investment rejects explicit null) and {@code assets} is always
+     * included, even when empty. The payload is serialised to {@code byte[]} because
+     * {@code RestTemplate} does not reliably serialise {@link ObjectNode} bodies.
+     */
+    private byte[] buildCreateRequestBodyBytes(EntryCreateUpdateRequest request) {
+        ObjectNode requestBody = objectMapper.valueToTree(request);
+        requestBody.remove(JSON_PROPERTY_THUMBNAIL);
+        requestBody.set(JSON_PROPERTY_ASSETS, objectMapper.valueToTree(
+            Objects.requireNonNullElse(request.getAssets(), List.of())));
+
+        try {
+            return objectMapper.writeValueAsBytes(requestBody);
+        } catch (JsonProcessingException exception) {
+            throw new IllegalStateException("Failed to serialize content entry create request", exception);
+        }
+    }
+
     private Flux<MarketNewsEntry> findEntriesNewContent(List<MarketNewsEntry> contentEntries) {
         Map<String, MarketNewsEntry> entryByTitle = contentEntries.stream()
             .collect(Collectors.toMap(MarketNewsEntry::getTitle, Function.identity()));
@@ -267,62 +332,4 @@ public class InvestmentRestNewsContentService {
 
         return Flux.fromIterable(newEntries);
     }
-
-    /**
-     * Attaches a thumbnail to a content entry via multipart PATCH when a thumbnail resource is provided.
-     * Failures are logged and swallowed so the created entry is retained without a thumbnail.
-     *
-     * @param entry the created content entry
-     * @param thumbnail optional thumbnail resource
-     * @return Mono emitting the entry (unchanged on success or when attachment is skipped or fails)
-     */
-    private Mono<EntryCreateUpdate> addThumbnail(EntryCreateUpdate entry, Resource thumbnail) {
-        UUID uuid = entry.getUuid();
-
-        if (thumbnail == null) {
-            log.debug("Skipping thumbnail attachment: uuid={}, title='{}'", uuid, entry.getTitle());
-            return Mono.just(entry);
-        }
-
-        log.debug("Attaching thumbnail to content entry: uuid={}, title='{}', thumbnailFile='{}'", uuid,
-            entry.getTitle(), getFileNameForLog(thumbnail));
-
-        return Mono.defer(() -> {
-                Map<String, Object> uriVariables = new HashMap<>();
-                uriVariables.put("uuid", uuid);
-
-                MultiValueMap<String, String> localVarQueryParams = new LinkedMultiValueMap<>();
-                HttpHeaders localVarHeaderParams = new HttpHeaders();
-                MultiValueMap<String, String> localVarCookieParams = new LinkedMultiValueMap<>();
-                MultiValueMap<String, Object> localVarFormParams = new LinkedMultiValueMap<>();
-
-                localVarFormParams.add("thumbnail", thumbnail);
-
-                final String[] localVarAccepts = {"application/json"};
-                final List<MediaType> localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
-                final String[] localVarContentTypes = {"multipart/form-data"};
-                final MediaType localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
-
-                String[] localVarAuthNames = new String[]{};
-
-                ParameterizedTypeReference<EntryCreateUpdate> localReturnType = new ParameterizedTypeReference<>() {
-                };
-                apiClient.invokeAPI("/service-api/v2/content/entries/{uuid}/", HttpMethod.PATCH, uriVariables,
-                    localVarQueryParams, null, localVarHeaderParams, localVarCookieParams, localVarFormParams,
-                    localVarAccept, localVarContentType, localVarAuthNames, localReturnType);
-
-                log.debug("Thumbnail attached successfully: uuid={}, title='{}', thumbnailFile='{}'", uuid,
-                    entry.getTitle(), getFileNameForLog(thumbnail));
-                return Mono.just(entry);
-            }).doOnError(error -> log.error(
-                "Thumbnail attachment failed: uuid={}, title='{}', thumbnailFile='{}', errorType={}, errorMessage={}",
-                uuid, entry.getTitle(), getFileNameForLog(thumbnail), error.getClass().getSimpleName(),
-                error.getMessage(), error))
-            .onErrorResume(error -> {
-                log.warn("Content entry created without thumbnail: uuid={}, title='{}', reason={}", uuid,
-                    entry.getTitle(), error.getMessage());
-                return Mono.just(entry);
-            });
-    }
-
 }

--- a/stream-investment/investment-core/src/main/java/com/backbase/stream/investment/service/resttemplate/InvestmentRestNewsContentService.java
+++ b/stream-investment/investment-core/src/main/java/com/backbase/stream/investment/service/resttemplate/InvestmentRestNewsContentService.java
@@ -11,7 +11,6 @@ import com.backbase.investment.api.service.sync.v1.model.EntryCreateUpdate;
 import com.backbase.investment.api.service.sync.v1.model.EntryCreateUpdateRequest;
 import com.backbase.investment.api.service.sync.v1.model.EntryTagRequest;
 import com.backbase.investment.api.service.sync.v1.model.PatchedEntryTagRequest;
-import com.backbase.investment.api.service.sync.v1.model.RelatedAssetSerializerWithAssetCategoriesRequest;
 import com.backbase.stream.investment.model.MarketNewsEntry;
 import com.backbase.stream.investment.model.ContentTag;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -21,9 +20,9 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 import java.util.Objects;
 import java.util.Set;
+import java.util.UUID;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -36,29 +35,32 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
-import org.springframework.web.client.RestClientException;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 /**
- * RestTemplate-based service for market news content and tags against the Investment service
- * {@code /service-api/v2/content/} endpoints.
+ * REST client service for upserting market news content and tags via the Investment Content API.
  *
- * <p>This service avoids serialisation issues present in the auto-generated
- * {@code ContentApi#createContentEntry} client introduced with investment-service-api 1.6.x:
+ * <p>This service manages:
  * <ul>
- *   <li>explicit {@code thumbnail: null} is rejected by the investment API</li>
- *   <li>empty {@code assets} arrays must be present on create</li>
- *   <li>multipart create does not reliably transmit JSON array fields</li>
- *   <li>{@code ObjectNode} request bodies are not always serialised by {@code RestTemplate}</li>
+ *   <li>Market news tag creation and updates</li>
+ *   <li>Market news content entry creation (skips duplicates by title)</li>
+ *   <li>Thumbnail attachment for newly created content entries</li>
  * </ul>
  *
  * <p>Content entry create uses JSON {@code POST /service-api/v2/content/entries/} via
- * {@link ApiClient#invokeAPI}; optional thumbnail upload uses multipart
- * {@code PATCH /service-api/v2/content/entries/{uuid}/}. Mapping from the stream
- * {@link MarketNewsEntry} model is handled by {@link ContentMapper}.
+ * {@link ApiClient#invokeAPI} instead of the generated {@code ContentApi#createContentEntry},
+ * because investment-service-api 1.6.x rejects explicit {@code thumbnail: null}, requires an
+ * {@code assets} array (including empty), and multipart create does not reliably transmit JSON
+ * array fields. Thumbnail upload remains a multipart PATCH.
  *
- * @see InvestmentRestDocumentContentService
+ * <p>Design notes (see CODING_RULES_COPILOT.md):
+ * <ul>
+ *   <li>No direct manipulation of generated API classes beyond construction and mapping</li>
+ *   <li>Side-effecting operations are logged at info (create) or debug (patch) levels</li>
+ *   <li>Individual entry failures are logged and swallowed so batch processing continues</li>
+ *   <li>All reactive operations include proper success and error handlers for observability</li>
+ * </ul>
  */
 @Slf4j
 @RequiredArgsConstructor
@@ -68,10 +70,7 @@ public class InvestmentRestNewsContentService {
     public static final int CONTENT_RETRIEVE_LIMIT = 100;
 
     private static final String CREATE_CONTENT_ENTRY_PATH = "/service-api/v2/content/entries/";
-    private static final String PATCH_CONTENT_ENTRY_PATH = "/service-api/v2/content/entries/{uuid}/";
-
     private static final String[] JSON_CONTENT_TYPES = {"application/json"};
-    private static final String[] MULTIPART_CONTENT_TYPES = {"multipart/form-data"};
 
     private final ContentApi contentApi;
     private final ApiClient apiClient;
@@ -79,10 +78,12 @@ public class InvestmentRestNewsContentService {
     private final ContentMapper contentMapper = Mappers.getMapper(ContentMapper.class);
 
     /**
-     * Creates or updates market news tags via {@code ContentApi} entry-tag endpoints.
+     * Upserts a batch of content tags. For each tag, checks whether a tag with the same code already exists.
+     * If found, patches it; otherwise creates a new tag. Tags with blank code or value are skipped.
+     * Individual failures are logged and swallowed so remaining tags continue processing.
      *
-     * @param tagEntries tags to upsert
-     * @return {@link Mono} that completes when all tags have been processed
+     * @param tagEntries list of tags to upsert
+     * @return Mono that completes when all tags have been processed
      */
     public Mono<Void> upsertTags(List<ContentTag> tagEntries) {
         log.info("Starting tag upsert batch operation: totalEntriesSubmitted={}", tagEntries.size());
@@ -101,31 +102,19 @@ public class InvestmentRestNewsContentService {
     }
 
     /**
-     * Creates new market news content entries that are not already present in the investment service.
+     * Upserts a single tag entry using the ContentApi tag endpoints. Implementation follows the upsert pattern:
+     * <ol>
+     *   <li>List existing tag entries to check if the tag code already exists</li>
+     *   <li>If tag exists, patch it with the new value</li>
+     *   <li>If not found, create a new tag entry</li>
+     * </ol>
      *
-     * @param contentEntries news entries to upsert
-     * @return {@link Mono} that completes when all new entries have been processed
+     * @param marketNewsTag the tag to upsert
+     * @return Mono that completes with the tag when processed, or empty if validation fails or an error occurs
      */
-    public Mono<Void> upsertContent(List<MarketNewsEntry> contentEntries) {
-        log.info("Starting content upsert batch operation: totalEntriesSubmitted={}", contentEntries.size());
-        log.debug("Content upsert batch details: entries={}", contentEntries);
-
-        return findEntriesNewContent(contentEntries)
-            .flatMap(this::upsertSingleEntry)
-            .count()
-            .doOnNext(entriesCreated -> log.info(
-                "Content upsert batch completed successfully: totalEntriesSubmitted={}, entriesCreated={}",
-                contentEntries.size(), entriesCreated))
-            .doOnError(error -> log.error(
-                "Content upsert batch failed: totalEntriesSubmitted={}, errorType={}, errorMessage={}",
-                contentEntries.size(), error.getClass().getSimpleName(), error.getMessage(), error))
-            .then();
-    }
-
     private Mono<ContentTag> upsertSingleTag(ContentTag marketNewsTag) {
         log.debug("Processing tag: code='{}', value='{}'", marketNewsTag.getCode(), marketNewsTag.getValue());
 
-        // Validation
         if (marketNewsTag.getCode() == null || marketNewsTag.getCode().isBlank()) {
             log.warn("Skipping tag with empty code: value='{}'", marketNewsTag.getValue());
             return Mono.empty();
@@ -139,8 +128,8 @@ public class InvestmentRestNewsContentService {
         log.debug("Checking if tag entry exists: code='{}', value='{}'",
             marketNewsTag.getCode(), marketNewsTag.getValue());
 
-        // Check if tag entry already exists
-        return Mono.fromCallable(() -> contentApi.contentEntryTagList(CONTENT_RETRIEVE_LIMIT, 0))
+        return Mono.fromCallable(() ->
+                contentApi.contentEntryTagList(CONTENT_RETRIEVE_LIMIT, 0))
             .map(paginatedList -> paginatedList.getResults().stream()
                 .filter(Objects::nonNull)
                 .filter(entry -> marketNewsTag.getCode().equals(entry.getCode()))
@@ -166,6 +155,12 @@ public class InvestmentRestNewsContentService {
             });
     }
 
+    /**
+     * Creates a new tag entry using the ContentApi.
+     *
+     * @param contentTag the tag to create an entry for
+     * @return Mono of the created tag
+     */
     private Mono<ContentTag> createTagEntry(ContentTag contentTag) {
         EntryTagRequest request = new EntryTagRequest()
             .code(contentTag.getCode())
@@ -182,6 +177,12 @@ public class InvestmentRestNewsContentService {
             .thenReturn(contentTag);
     }
 
+    /**
+     * Patches an existing tag entry with updated values.
+     *
+     * @param contentTag the tag with updated values to patch
+     * @return Mono of the patched tag
+     */
     private Mono<ContentTag> patchTagEntry(ContentTag contentTag) {
         PatchedEntryTagRequest request = new PatchedEntryTagRequest()
             .code(contentTag.getCode())
@@ -198,11 +199,46 @@ public class InvestmentRestNewsContentService {
             .thenReturn(contentTag);
     }
 
+    /**
+     * Creates new market news content entries. Entries whose title matches an existing entry are skipped.
+     * Individual failures are logged and swallowed so remaining entries continue processing.
+     *
+     * @param contentEntries list of content entries to create
+     * @return Mono that completes when all eligible entries have been processed
+     */
+    public Mono<Void> upsertContent(List<MarketNewsEntry> contentEntries) {
+        log.info("Starting content entries upsert batch operation: totalEntriesSubmitted={}", contentEntries.size());
+        log.debug("Content upsert batch details: entries={}", contentEntries);
+
+        return findEntriesNewContent(contentEntries)
+            .flatMap(this::upsertSingleEntry)
+            .count()
+            .doOnNext(entriesCreated -> log.info(
+                "Content upsert batch completed successfully: totalEntriesSubmitted={}, entriesCreated={}",
+                contentEntries.size(), entriesCreated))
+            .doOnError(error -> log.error(
+                "Content upsert batch failed: totalEntriesSubmitted={}, errorType={}, errorMessage={}",
+                contentEntries.size(), error.getClass().getSimpleName(), error.getMessage(), error))
+            .then();
+    }
+
+    /**
+     * Creates a single market news content entry and optionally attaches a thumbnail.
+     * Callers must supply entries that have already been filtered as non-duplicates.
+     * Errors are logged and swallowed to allow processing of remaining entries.
+     *
+     * @param request the content entry to create
+     * @return Mono that completes with the created entry, or empty if creation fails
+     */
     private Mono<EntryCreateUpdate> upsertSingleEntry(MarketNewsEntry request) {
         log.debug("Creating content entry: title='{}', hasThumbnail={}", request.getTitle(),
             request.getThumbnailResource() != null);
 
-        return Mono.defer(() -> Mono.fromCallable(() -> invokeCreateContentEntry(request)))
+        EntryCreateUpdateRequest createUpdateRequest = contentMapper.map(request);
+        log.debug("Content entry request mapped: title='{}', request={}", request.getTitle(), createUpdateRequest);
+
+        return Mono.defer(() -> Mono.fromCallable(() -> createContentEntry(createUpdateRequest)))
+            .flatMap(entry -> addThumbnail(entry, request.getThumbnailResource()))
             .doOnSuccess(created -> log.info(
                 "Content entry created successfully: title='{}', uuid={}, thumbnailAttached={}",
                 request.getTitle(), created.getUuid(), request.getThumbnailResource() != null))
@@ -213,26 +249,26 @@ public class InvestmentRestNewsContentService {
     }
 
     /**
-     * Creates a content entry and optionally attaches a thumbnail file.
+     * Creates a content entry via JSON POST.
      *
-     * @throws RestClientException if the investment service returns an error
+     * <p>{@code thumbnail} is omitted (investment rejects explicit null) and {@code assets} is always
+     * included, even when empty. The payload is serialised to {@code byte[]} because
+     * {@code RestTemplate} does not reliably serialise {@link ObjectNode} bodies.
      */
-    private EntryCreateUpdate invokeCreateContentEntry(MarketNewsEntry entry) throws RestClientException {
-        EntryCreateUpdateRequest request = contentMapper.map(entry);
-        EntryCreateUpdate created = invokeCreate(request);
+    private EntryCreateUpdate createContentEntry(EntryCreateUpdateRequest request) {
+        ObjectNode requestBody = objectMapper.valueToTree(request);
+        requestBody.remove(JSON_PROPERTY_THUMBNAIL);
+        requestBody.set(JSON_PROPERTY_ASSETS, objectMapper.valueToTree(
+            Objects.requireNonNullElse(request.getAssets(), List.of())));
 
-        Resource thumbnail = entry.getThumbnailResource();
-        if (thumbnail != null) {
-            return invokePatchThumbnail(created.getUuid(), thumbnail);
+        final byte[] bodyBytes;
+        try {
+            bodyBytes = objectMapper.writeValueAsBytes(requestBody);
+        } catch (JsonProcessingException exception) {
+            throw new IllegalStateException("Failed to serialize content entry create request", exception);
         }
-        return created;
-    }
 
-    private EntryCreateUpdate invokeCreate(EntryCreateUpdateRequest request) throws RestClientException {
-        byte[] bodyBytes = buildCreateRequestBodyBytes(request);
-        log.debug("Creating content entry JSON payload: title='{}'", request.getTitle());
-
-        final List<MediaType> accept = apiClient.selectHeaderAccept(new String[]{"application/json"});
+        final List<MediaType> accept = apiClient.selectHeaderAccept(JSON_CONTENT_TYPES);
         final MediaType contentType = apiClient.selectHeaderContentType(JSON_CONTENT_TYPES);
         ParameterizedTypeReference<EntryCreateUpdate> returnType = new ParameterizedTypeReference<>() {
         };
@@ -253,56 +289,13 @@ public class InvestmentRestNewsContentService {
             .getBody();
     }
 
-    private EntryCreateUpdate invokePatchThumbnail(UUID uuid, Resource thumbnail) throws RestClientException {
-        final Map<String, Object> uriVariables = new HashMap<>();
-        uriVariables.put("uuid", uuid.toString());
-
-        final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<>();
-        log.debug("Patching content entry thumbnail: uuid={}, thumbnailFile='{}'",
-            uuid, getFileNameForLog(thumbnail));
-        formParams.add(JSON_PROPERTY_THUMBNAIL, thumbnail);
-
-        final List<MediaType> accept = apiClient.selectHeaderAccept(new String[]{"application/json"});
-        final MediaType contentType = apiClient.selectHeaderContentType(MULTIPART_CONTENT_TYPES);
-        ParameterizedTypeReference<EntryCreateUpdate> returnType = new ParameterizedTypeReference<>() {
-        };
-
-        return apiClient.invokeAPI(
-                PATCH_CONTENT_ENTRY_PATH,
-                HttpMethod.PATCH,
-                uriVariables,
-                new LinkedMultiValueMap<>(),
-                null,
-                new HttpHeaders(),
-                new LinkedMultiValueMap<>(),
-                formParams,
-                accept,
-                contentType,
-                new String[]{},
-                returnType)
-            .getBody();
-    }
-
     /**
-     * Builds JSON request bytes for content entry create.
+     * Filters the supplied content entries to those not already present in the system.
+     * An entry is considered a duplicate when its title contains an existing entry title.
      *
-     * <p>{@code thumbnail} is omitted (investment rejects explicit null) and {@code assets} is always
-     * included, even when empty. The payload is serialised to {@code byte[]} because
-     * {@code RestTemplate} does not reliably serialise {@link ObjectNode} bodies.
+     * @param contentEntries entries to filter
+     * @return Flux of entries that should be created
      */
-    private byte[] buildCreateRequestBodyBytes(EntryCreateUpdateRequest request) {
-        ObjectNode requestBody = objectMapper.valueToTree(request);
-        requestBody.remove(JSON_PROPERTY_THUMBNAIL);
-        requestBody.set(JSON_PROPERTY_ASSETS, objectMapper.valueToTree(
-            Objects.requireNonNullElse(request.getAssets(), List.of())));
-
-        try {
-            return objectMapper.writeValueAsBytes(requestBody);
-        } catch (JsonProcessingException exception) {
-            throw new IllegalStateException("Failed to serialize content entry create request", exception);
-        }
-    }
-
     private Flux<MarketNewsEntry> findEntriesNewContent(List<MarketNewsEntry> contentEntries) {
         Map<String, MarketNewsEntry> entryByTitle = contentEntries.stream()
             .collect(Collectors.toMap(MarketNewsEntry::getTitle, Function.identity()));
@@ -332,4 +325,61 @@ public class InvestmentRestNewsContentService {
 
         return Flux.fromIterable(newEntries);
     }
+
+    /**
+     * Attaches a thumbnail to a content entry via multipart PATCH when a thumbnail resource is provided.
+     * Failures are logged and swallowed so the created entry is retained without a thumbnail.
+     *
+     * @param entry the created content entry
+     * @param thumbnail optional thumbnail resource
+     * @return Mono emitting the entry (unchanged on success or when attachment is skipped or fails)
+     */
+    private Mono<EntryCreateUpdate> addThumbnail(EntryCreateUpdate entry, Resource thumbnail) {
+        UUID uuid = entry.getUuid();
+
+        if (thumbnail == null) {
+            log.debug("Skipping thumbnail attachment: uuid={}, title='{}'", uuid, entry.getTitle());
+            return Mono.just(entry);
+        }
+
+        log.debug("Attaching thumbnail to content entry: uuid={}, title='{}', thumbnailFile='{}'", uuid,
+            entry.getTitle(), getFileNameForLog(thumbnail));
+
+        return Mono.defer(() -> {
+                Map<String, Object> uriVariables = new HashMap<>();
+                uriVariables.put("uuid", uuid);
+
+                MultiValueMap<String, String> localVarQueryParams = new LinkedMultiValueMap<>();
+                HttpHeaders localVarHeaderParams = new HttpHeaders();
+                MultiValueMap<String, String> localVarCookieParams = new LinkedMultiValueMap<>();
+                MultiValueMap<String, Object> localVarFormParams = new LinkedMultiValueMap<>();
+
+                localVarFormParams.add(JSON_PROPERTY_THUMBNAIL, thumbnail);
+
+                final List<MediaType> localVarAccept = apiClient.selectHeaderAccept(JSON_CONTENT_TYPES);
+                final String[] localVarContentTypes = {"multipart/form-data"};
+                final MediaType localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
+
+                String[] localVarAuthNames = new String[]{};
+
+                ParameterizedTypeReference<EntryCreateUpdate> localReturnType = new ParameterizedTypeReference<>() {
+                };
+                apiClient.invokeAPI("/service-api/v2/content/entries/{uuid}/", HttpMethod.PATCH, uriVariables,
+                    localVarQueryParams, null, localVarHeaderParams, localVarCookieParams, localVarFormParams,
+                    localVarAccept, localVarContentType, localVarAuthNames, localReturnType);
+
+                log.debug("Thumbnail attached successfully: uuid={}, title='{}', thumbnailFile='{}'", uuid,
+                    entry.getTitle(), getFileNameForLog(thumbnail));
+                return Mono.just(entry);
+            }).doOnError(error -> log.error(
+                "Thumbnail attachment failed: uuid={}, title='{}', thumbnailFile='{}', errorType={}, errorMessage={}",
+                uuid, entry.getTitle(), getFileNameForLog(thumbnail), error.getClass().getSimpleName(),
+                error.getMessage(), error))
+            .onErrorResume(error -> {
+                log.warn("Content entry created without thumbnail: uuid={}, title='{}', reason={}", uuid,
+                    entry.getTitle(), error.getMessage());
+                return Mono.just(entry);
+            });
+    }
+
 }

--- a/stream-investment/investment-core/src/test/java/com/backbase/stream/configuration/InvestmentRestServiceApiConfigurationTest.java
+++ b/stream-investment/investment-core/src/test/java/com/backbase/stream/configuration/InvestmentRestServiceApiConfigurationTest.java
@@ -70,7 +70,8 @@ class InvestmentRestServiceApiConfigurationTest {
     @Test
     @DisplayName("investmentNewsContentService returns non-null InvestmentRestNewsContentService")
     void investmentNewsContentService_returnsNewsContentService() {
-        assertThat(config.investmentNewsContentService(mock(ContentApi.class), syncApiClient))
+        assertThat(config.investmentNewsContentService(
+                mock(ContentApi.class), syncApiClient, config.restInvestmentObjectMapper(new ObjectMapper())))
             .isNotNull().isInstanceOf(InvestmentRestNewsContentService.class);
     }
 

--- a/stream-investment/investment-core/src/test/java/com/backbase/stream/investment/service/InvestmentPortfolioServiceTest.java
+++ b/stream-investment/investment-core/src/test/java/com/backbase/stream/investment/service/InvestmentPortfolioServiceTest.java
@@ -1,5 +1,6 @@
 package com.backbase.stream.investment.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
@@ -15,12 +16,14 @@ import com.backbase.investment.api.service.v1.PortfolioApi;
 import com.backbase.investment.api.service.v1.PortfolioTradingAccountsApi;
 import com.backbase.investment.api.service.v1.model.Deposit;
 import com.backbase.investment.api.service.v1.model.DepositRequest;
+import com.backbase.investment.api.service.v1.model.IntegrationPortfolioCreateRequest;
 import com.backbase.investment.api.service.v1.model.IntegrationWithdrawalCreate;
 import com.backbase.investment.api.service.v1.model.IntegrationWithdrawalList;
 import com.backbase.investment.api.service.v1.model.PaginatedDepositList;
 import com.backbase.investment.api.service.v1.model.PaginatedIntegrationWithdrawalListList;
 import com.backbase.investment.api.service.v1.model.PaginatedPortfolioListList;
 import com.backbase.investment.api.service.v1.model.PaginatedPortfolioTradingAccountList;
+import com.backbase.investment.api.service.v1.model.PatchedPortfolioUpdateRequest;
 import com.backbase.investment.api.service.v1.model.PortfolioList;
 import com.backbase.investment.api.service.v1.model.PortfolioProduct;
 import com.backbase.investment.api.service.v1.model.PortfolioTradingAccount;
@@ -42,6 +45,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -597,6 +601,115 @@ class InvestmentPortfolioServiceTest {
 
             verify(portfolioApi).createPortfolio(any(), isNull(), isNull(), isNull());
             verify(portfolioApi, never()).patchPortfolio(any(), any(), any(), any(), any());
+        }
+
+        @Test
+        @DisplayName("create portfolio — forwards arrangement extraData on create request")
+        void upsertInvestmentPortfolios_create_forwardsExtraData() {
+            UUID portfolioUuid = UUID.randomUUID();
+            UUID productId = UUID.randomUUID();
+            String externalId = "PORTFOLIO-EXT-EXTRA-CREATE";
+            String leExternalId = "LE-EXTRA-CREATE";
+            UUID clientUuid = UUID.randomUUID();
+            Map<String, String> extraData = Map.of("riskLevel", "Low", "ignoreMarketHoursForTest", "false");
+
+            InvestmentArrangement arrangement = buildArrangement(externalId, "Extra Create Portfolio", productId,
+                leExternalId);
+            when(arrangement.getExtraData()).thenReturn(extraData);
+
+            PaginatedPortfolioListList emptyList = Mockito.mock(PaginatedPortfolioListList.class);
+            when(emptyList.getResults()).thenReturn(List.of());
+            when(portfolioApi.listPortfolios(isNull(), isNull(), isNull(),
+                isNull(), eq(externalId), isNull(), isNull(), eq(1),
+                isNull(), isNull(), isNull(), isNull()))
+                .thenReturn(Mono.just(emptyList));
+
+            PortfolioList created = buildPortfolioList(portfolioUuid, externalId, OffsetDateTime.now().minusMonths(6));
+            when(portfolioApi.createPortfolio(any(), isNull(), isNull(), isNull()))
+                .thenReturn(Mono.just(created));
+
+            StepVerifier.create(service.upsertInvestmentPortfolios(arrangement,
+                    Map.of(leExternalId, List.of(clientUuid))))
+                .expectNextMatches(p -> portfolioUuid.equals(p.getUuid()))
+                .verifyComplete();
+
+            ArgumentCaptor<IntegrationPortfolioCreateRequest> requestCaptor =
+                ArgumentCaptor.forClass(IntegrationPortfolioCreateRequest.class);
+            verify(portfolioApi).createPortfolio(requestCaptor.capture(), isNull(), isNull(), isNull());
+            assertThat(requestCaptor.getValue().getExtraData()).isEqualTo(extraData);
+        }
+
+        @Test
+        @DisplayName("patch portfolio — forwards arrangement extraData on patch request")
+        void upsertInvestmentPortfolios_patch_forwardsExtraData() {
+            UUID portfolioUuid = UUID.randomUUID();
+            UUID productId = UUID.randomUUID();
+            String externalId = "PORTFOLIO-EXT-EXTRA-PATCH";
+            String leExternalId = "LE-EXTRA-PATCH";
+            UUID clientUuid = UUID.randomUUID();
+            Map<String, String> extraData = Map.of("riskLevel", "High");
+
+            InvestmentArrangement arrangement = buildArrangement(externalId, "Extra Patch Portfolio", productId,
+                leExternalId);
+            when(arrangement.getExtraData()).thenReturn(extraData);
+
+            PortfolioList existing = buildPortfolioList(portfolioUuid, externalId, OffsetDateTime.now().minusMonths(6));
+            PortfolioList patched = buildPortfolioList(portfolioUuid, externalId, OffsetDateTime.now().minusMonths(6));
+
+            PaginatedPortfolioListList paginatedList = Mockito.mock(PaginatedPortfolioListList.class);
+            when(paginatedList.getResults()).thenReturn(List.of(existing));
+            when(portfolioApi.listPortfolios(isNull(), isNull(), isNull(),
+                isNull(), eq(externalId), isNull(), isNull(), eq(1),
+                isNull(), isNull(), isNull(), isNull()))
+                .thenReturn(Mono.just(paginatedList));
+            when(portfolioApi.patchPortfolio(eq(portfolioUuid.toString()), isNull(), isNull(), isNull(), any()))
+                .thenReturn(Mono.just(patched));
+
+            StepVerifier.create(service.upsertInvestmentPortfolios(arrangement,
+                    Map.of(leExternalId, List.of(clientUuid))))
+                .expectNextMatches(p -> portfolioUuid.equals(p.getUuid()))
+                .verifyComplete();
+
+            ArgumentCaptor<PatchedPortfolioUpdateRequest> requestCaptor =
+                ArgumentCaptor.forClass(PatchedPortfolioUpdateRequest.class);
+            verify(portfolioApi).patchPortfolio(eq(portfolioUuid.toString()), isNull(), isNull(), isNull(),
+                requestCaptor.capture());
+            assertThat(requestCaptor.getValue().getExtraData()).isEqualTo(extraData);
+        }
+
+        @Test
+        @DisplayName("create portfolio — leaves extraData null when arrangement has none")
+        void upsertInvestmentPortfolios_create_nullExtraDataWhenAbsent() {
+            UUID portfolioUuid = UUID.randomUUID();
+            UUID productId = UUID.randomUUID();
+            String externalId = "PORTFOLIO-EXT-NO-EXTRA";
+            String leExternalId = "LE-NO-EXTRA";
+            UUID clientUuid = UUID.randomUUID();
+
+            InvestmentArrangement arrangement = buildArrangement(externalId, "No Extra Portfolio", productId,
+                leExternalId);
+            when(arrangement.getExtraData()).thenReturn(null);
+
+            PaginatedPortfolioListList emptyList = Mockito.mock(PaginatedPortfolioListList.class);
+            when(emptyList.getResults()).thenReturn(List.of());
+            when(portfolioApi.listPortfolios(isNull(), isNull(), isNull(),
+                isNull(), eq(externalId), isNull(), isNull(), eq(1),
+                isNull(), isNull(), isNull(), isNull()))
+                .thenReturn(Mono.just(emptyList));
+
+            PortfolioList created = buildPortfolioList(portfolioUuid, externalId, OffsetDateTime.now().minusMonths(6));
+            when(portfolioApi.createPortfolio(any(), isNull(), isNull(), isNull()))
+                .thenReturn(Mono.just(created));
+
+            StepVerifier.create(service.upsertInvestmentPortfolios(arrangement,
+                    Map.of(leExternalId, List.of(clientUuid))))
+                .expectNextMatches(p -> portfolioUuid.equals(p.getUuid()))
+                .verifyComplete();
+
+            ArgumentCaptor<IntegrationPortfolioCreateRequest> requestCaptor =
+                ArgumentCaptor.forClass(IntegrationPortfolioCreateRequest.class);
+            verify(portfolioApi).createPortfolio(requestCaptor.capture(), isNull(), isNull(), isNull());
+            assertThat(requestCaptor.getValue().getExtraData()).isNull();
         }
 
         @Test

--- a/stream-investment/investment-core/src/test/java/com/backbase/stream/investment/service/resttemplate/InvestmentRestNewsContentServiceTest.java
+++ b/stream-investment/investment-core/src/test/java/com/backbase/stream/investment/service/resttemplate/InvestmentRestNewsContentServiceTest.java
@@ -48,12 +48,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.util.MultiValueMap;
 import reactor.test.StepVerifier;
 
-/**
- * Unit tests for {@link InvestmentRestNewsContentService}.
- *
- * <p>Verifies tag upsert via generated {@code ContentApi} clients and content entry create via
- * manual {@code ApiClient} calls (JSON POST with {@code byte[]} body, optional multipart thumbnail PATCH).
- */
 @ExtendWith(MockitoExtension.class)
 class InvestmentRestNewsContentServiceTest {
 
@@ -105,7 +99,7 @@ class InvestmentRestNewsContentServiceTest {
         when(apiClient.invokeAPI(
             eq("/service-api/v2/content/entries/{uuid}/"),
             eq(HttpMethod.PATCH),
-            eq(Map.of("uuid", uuid.toString())),
+            eq(Map.of("uuid", uuid)),
             any(),
             isNull(),
             any(),
@@ -119,9 +113,9 @@ class InvestmentRestNewsContentServiceTest {
 
     static Stream<org.junit.jupiter.params.provider.Arguments> invalidTags() {
         return Stream.of(
-            org.junit.jupiter.params.provider.Arguments.of("  ", "someValue"),
-            org.junit.jupiter.params.provider.Arguments.of("code1", null),
-            org.junit.jupiter.params.provider.Arguments.of("code1", "  ")
+            org.junit.jupiter.params.provider.Arguments.of("  ", "someValue"),  // blank code
+            org.junit.jupiter.params.provider.Arguments.of("code1", null),      // null value
+            org.junit.jupiter.params.provider.Arguments.of("code1", "  ")       // blank value
         );
     }
 
@@ -151,9 +145,12 @@ class InvestmentRestNewsContentServiceTest {
                 .verifyComplete();
 
             verify(contentApi, never()).contentEntryTagList(anyInt(), anyInt());
+            verify(contentApi, never()).contentEntryTagCreate(any());
+            verify(contentApi, never()).contentEntryTagPartialUpdate(any(), any());
         }
 
         @ParameterizedTest(name = "tag skipped when code=''{0}'' value=''{1}''")
+        @DisplayName("tag with blank/null code or blank/null value is skipped")
         @MethodSource("com.backbase.stream.investment.service.resttemplate.InvestmentRestNewsContentServiceTest#invalidTags")
         void tagWithInvalidCodeOrValueIsSkipped(String code, String value) {
             ContentTag tag = new ContentTag(code, value);
@@ -162,6 +159,7 @@ class InvestmentRestNewsContentServiceTest {
                 .verifyComplete();
 
             verify(contentApi, never()).contentEntryTagList(anyInt(), anyInt());
+            verify(contentApi, never()).contentEntryTagCreate(any());
         }
 
         @Test
@@ -178,6 +176,65 @@ class InvestmentRestNewsContentServiceTest {
                 .verifyComplete();
 
             verify(contentApi, times(1)).contentEntryTagCreate(any());
+            verify(contentApi, never()).contentEntryTagPartialUpdate(any(), any());
+        }
+
+        @Test
+        @DisplayName("existing tag triggers patch")
+        void existingTagTriggersPatch() {
+            ContentTag tag = new ContentTag("code1", "value1");
+            EntryTag existingTag = new EntryTag().code("code1").value("oldValue");
+            PaginatedEntryTagList page = new PaginatedEntryTagList().results(List.of(existingTag));
+            EntryTag patchedTag = new EntryTag().code("code1").value("value1");
+
+            when(contentApi.contentEntryTagList(anyInt(), anyInt())).thenReturn(page);
+            when(contentApi.contentEntryTagPartialUpdate(anyString(), any())).thenReturn(patchedTag);
+
+            StepVerifier.create(service.upsertTags(List.of(tag)))
+                .verifyComplete();
+
+            verify(contentApi, times(1)).contentEntryTagPartialUpdate(anyString(), any());
+            verify(contentApi, never()).contentEntryTagCreate(any());
+        }
+
+        @Test
+        @DisplayName("API failure on tag create is swallowed and processing continues")
+        void apiFailureOnTagCreateIsSwallowed() {
+            ContentTag tag1 = new ContentTag("code1", "value1");
+            ContentTag tag2 = new ContentTag("code2", "value2");
+            PaginatedEntryTagList emptyPage = new PaginatedEntryTagList().results(List.of());
+            EntryTag createdTag2 = new EntryTag().code("code2").value("value2");
+
+            when(contentApi.contentEntryTagList(anyInt(), anyInt())).thenReturn(emptyPage);
+            when(contentApi.contentEntryTagCreate(any()))
+                .thenThrow(new RuntimeException("API error"))
+                .thenReturn(createdTag2);
+
+            StepVerifier.create(service.upsertTags(List.of(tag1, tag2)))
+                .verifyComplete();
+
+            verify(contentApi, times(2)).contentEntryTagCreate(any());
+        }
+
+        @Test
+        @DisplayName("multiple tags: existing gets patched, new gets created")
+        void multipleTagsAllProcessed() {
+            ContentTag tag1 = new ContentTag("code1", "value1");
+            ContentTag tag2 = new ContentTag("code2", "value2");
+            EntryTag existingTag1 = new EntryTag().code("code1").value("old1");
+            PaginatedEntryTagList page = new PaginatedEntryTagList().results(List.of(existingTag1));
+            EntryTag patchedTag = new EntryTag().code("code1").value("value1");
+            EntryTag createdTag = new EntryTag().code("code2").value("value2");
+
+            when(contentApi.contentEntryTagList(anyInt(), anyInt())).thenReturn(page);
+            when(contentApi.contentEntryTagPartialUpdate(anyString(), any())).thenReturn(patchedTag);
+            when(contentApi.contentEntryTagCreate(any())).thenReturn(createdTag);
+
+            StepVerifier.create(service.upsertTags(List.of(tag1, tag2)))
+                .verifyComplete();
+
+            verify(contentApi, times(1)).contentEntryTagPartialUpdate(anyString(), any());
+            verify(contentApi, times(1)).contentEntryTagCreate(any());
         }
     }
 
@@ -190,8 +247,23 @@ class InvestmentRestNewsContentServiceTest {
     class UpsertContent {
 
         @Test
-        @DisplayName("no thumbnail uses JSON POST without thumbnail field")
-        void noThumbnailUsesJsonPost() throws Exception {
+        @DisplayName("empty list completes without calling API")
+        void emptyListCompletesWithoutApiCall() {
+            PaginatedEntryList emptyPage = new PaginatedEntryList().results(List.of());
+            when(contentApi.listContentEntries(isNull(), anyInt(), anyInt(),
+                isNull(), isNull(), isNull(), isNull())).thenReturn(emptyPage);
+
+            StepVerifier.create(service.upsertContent(List.of()))
+                .verifyComplete();
+
+            verify(apiClient, never()).invokeAPI(
+                eq("/service-api/v2/content/entries/"), eq(HttpMethod.POST), any(), any(), any(), any(), any(), any(),
+                any(), any(), any(), any());
+        }
+
+        @Test
+        @DisplayName("no existing entries - all entries are created via JSON POST")
+        void noExistingEntriesAllCreated() throws Exception {
             MarketNewsEntry entry = new MarketNewsEntry();
             entry.setTitle("News Title");
             entry.setTags(List.of("INVESTOR_AREA"));
@@ -207,6 +279,10 @@ class InvestmentRestNewsContentServiceTest {
             StepVerifier.create(service.upsertContent(List.of(entry)))
                 .verifyComplete();
 
+            verify(apiClient, times(1)).invokeAPI(
+                eq("/service-api/v2/content/entries/"), eq(HttpMethod.POST), any(), any(), any(), any(), any(), any(),
+                any(), eq(MediaType.APPLICATION_JSON), any(), any());
+
             byte[] bodyBytes = (byte[]) jsonBodyCaptor.getValue();
             JsonNode body = objectMapper.readTree(bodyBytes);
             assertThat(body.has(JSON_PROPERTY_THUMBNAIL)).isFalse();
@@ -215,40 +291,7 @@ class InvestmentRestNewsContentServiceTest {
         }
 
         @Test
-        @DisplayName("thumbnail resource uses JSON create then multipart PATCH for thumbnail")
-        void thumbnailUsesJsonCreateThenMultipartPatch() {
-            MarketNewsEntry entry = new MarketNewsEntry();
-            entry.setTitle("News Title");
-            entry.setTags(List.of("INVESTOR_AREA"));
-            entry.setThumbnailResource(new ByteArrayResource("image".getBytes(), "example.png"));
-
-            PaginatedEntryList emptyPage = new PaginatedEntryList().results(List.of());
-            UUID createdUuid = UUID.randomUUID();
-            EntryCreateUpdate created = new EntryCreateUpdate(createdUuid, null, null);
-            created.setTitle("News Title");
-            EntryCreateUpdate patched = new EntryCreateUpdate(createdUuid, null, null);
-            patched.setTitle("News Title");
-
-            when(contentApi.listContentEntries(isNull(), anyInt(), anyInt(),
-                isNull(), isNull(), isNull(), isNull())).thenReturn(emptyPage);
-            stubJsonContentEntryCreate(created);
-            stubMultipartContentEntryPatch(createdUuid, patched);
-
-            StepVerifier.create(service.upsertContent(List.of(entry)))
-                .verifyComplete();
-
-            verify(apiClient, times(1)).invokeAPI(
-                eq("/service-api/v2/content/entries/"), eq(HttpMethod.POST), any(), any(), any(), any(), any(), any(),
-                any(), eq(MediaType.APPLICATION_JSON), any(), any());
-            verify(apiClient, times(1)).invokeAPI(
-                eq("/service-api/v2/content/entries/{uuid}/"), eq(HttpMethod.PATCH), eq(Map.of("uuid", createdUuid.toString())),
-                any(), isNull(), any(), any(), any(), any(), eq(MediaType.MULTIPART_FORM_DATA), any(), any());
-            assertThat(formParamsCaptor.getValue().get(JSON_PROPERTY_THUMBNAIL)).hasSize(1);
-            assertThat(formParamsCaptor.getValue().get(JSON_PROPERTY_ASSETS)).isNull();
-        }
-
-        @Test
-        @DisplayName("existing entries with matching title are skipped")
+        @DisplayName("existing entries with matching title are skipped (not duplicated)")
         void existingEntriesWithMatchingTitleAreSkipped() {
             MarketNewsEntry entry = new MarketNewsEntry();
             entry.setTitle("Existing News");
@@ -266,6 +309,33 @@ class InvestmentRestNewsContentServiceTest {
             verify(apiClient, never()).invokeAPI(
                 eq("/service-api/v2/content/entries/"), eq(HttpMethod.POST), any(), any(), any(), any(), any(), any(),
                 any(), any(), any(), any());
+        }
+
+        @Test
+        @DisplayName("only new entries (not matching existing) are created")
+        void onlyNewEntriesAreCreated() {
+            MarketNewsEntry existingEntry = new MarketNewsEntry();
+            existingEntry.setTitle("Existing News");
+            MarketNewsEntry newEntry = new MarketNewsEntry();
+            newEntry.setTitle("Brand New News");
+            newEntry.setTags(List.of("INVESTOR_AREA"));
+
+            Entry serverEntry = new Entry(UUID.randomUUID(), "Existing News",
+                null, null, null, null, null, null, null, null);
+            PaginatedEntryList page = new PaginatedEntryList().results(List.of(serverEntry));
+            EntryCreateUpdate created = new EntryCreateUpdate(UUID.randomUUID(), null, null);
+            created.setTitle("Brand New News");
+
+            when(contentApi.listContentEntries(isNull(), anyInt(), anyInt(),
+                isNull(), isNull(), isNull(), isNull())).thenReturn(page);
+            stubJsonContentEntryCreate(created);
+
+            StepVerifier.create(service.upsertContent(List.of(existingEntry, newEntry)))
+                .verifyComplete();
+
+            verify(apiClient, times(1)).invokeAPI(
+                eq("/service-api/v2/content/entries/"), eq(HttpMethod.POST), any(), any(), any(), any(), any(), any(),
+                any(), eq(MediaType.APPLICATION_JSON), any(), any());
         }
 
         @Test
@@ -308,6 +378,110 @@ class InvestmentRestNewsContentServiceTest {
             verify(apiClient, times(2)).invokeAPI(
                 eq("/service-api/v2/content/entries/"), eq(HttpMethod.POST), any(), any(), any(), any(), any(), any(),
                 any(), eq(MediaType.APPLICATION_JSON), any(), any());
+        }
+
+        @Test
+        @DisplayName("entry without thumbnail skips thumbnail PATCH call via apiClient")
+        void entryWithoutThumbnailSkipsThumbnailAttachment() {
+            MarketNewsEntry entry = new MarketNewsEntry();
+            entry.setTitle("No Thumbnail News");
+            entry.setTags(List.of("INVESTOR_AREA"));
+
+            PaginatedEntryList emptyPage = new PaginatedEntryList().results(List.of());
+            EntryCreateUpdate created = new EntryCreateUpdate(UUID.randomUUID(), null, null);
+            created.setTitle("No Thumbnail News");
+
+            when(contentApi.listContentEntries(isNull(), anyInt(), anyInt(),
+                isNull(), isNull(), isNull(), isNull())).thenReturn(emptyPage);
+            stubJsonContentEntryCreate(created);
+
+            StepVerifier.create(service.upsertContent(List.of(entry)))
+                .verifyComplete();
+
+            verify(apiClient, times(1)).invokeAPI(
+                eq("/service-api/v2/content/entries/"), eq(HttpMethod.POST), any(), any(), any(), any(), any(), any(),
+                any(), eq(MediaType.APPLICATION_JSON), any(), any());
+            verify(apiClient, never()).invokeAPI(
+                eq("/service-api/v2/content/entries/{uuid}/"), eq(HttpMethod.PATCH), any(), any(), any(), any(), any(),
+                any(), any(), any(), any(), any());
+        }
+
+        @Test
+        @DisplayName("thumbnail resource uses JSON create then multipart PATCH for thumbnail")
+        void thumbnailUsesJsonCreateThenMultipartPatch() {
+            MarketNewsEntry entry = new MarketNewsEntry();
+            entry.setTitle("News Title");
+            entry.setTags(List.of("INVESTOR_AREA"));
+            entry.setThumbnailResource(new ByteArrayResource("image".getBytes(), "example.png"));
+
+            PaginatedEntryList emptyPage = new PaginatedEntryList().results(List.of());
+            UUID createdUuid = UUID.randomUUID();
+            EntryCreateUpdate created = new EntryCreateUpdate(createdUuid, null, null);
+            created.setTitle("News Title");
+            EntryCreateUpdate patched = new EntryCreateUpdate(createdUuid, null, null);
+            patched.setTitle("News Title");
+
+            when(contentApi.listContentEntries(isNull(), anyInt(), anyInt(),
+                isNull(), isNull(), isNull(), isNull())).thenReturn(emptyPage);
+            stubJsonContentEntryCreate(created);
+            stubMultipartContentEntryPatch(createdUuid, patched);
+
+            StepVerifier.create(service.upsertContent(List.of(entry)))
+                .verifyComplete();
+
+            verify(apiClient, times(1)).invokeAPI(
+                eq("/service-api/v2/content/entries/"), eq(HttpMethod.POST), any(), any(), any(), any(), any(), any(),
+                any(), eq(MediaType.APPLICATION_JSON), any(), any());
+            verify(apiClient, times(1)).invokeAPI(
+                eq("/service-api/v2/content/entries/{uuid}/"), eq(HttpMethod.PATCH),
+                eq(Map.of("uuid", createdUuid)), any(), isNull(), any(), any(), any(), any(),
+                eq(MediaType.MULTIPART_FORM_DATA), any(), any());
+            assertThat(formParamsCaptor.getValue().get(JSON_PROPERTY_THUMBNAIL)).hasSize(1);
+            assertThat(formParamsCaptor.getValue().get(JSON_PROPERTY_ASSETS)).isNull();
+        }
+
+        @Test
+        @DisplayName("thumbnail PATCH failure retains created entry")
+        void thumbnailPatchFailureRetainsCreatedEntry() {
+            MarketNewsEntry entry = new MarketNewsEntry();
+            entry.setTitle("News Title");
+            entry.setTags(List.of("INVESTOR_AREA"));
+            entry.setThumbnailResource(new ByteArrayResource("image".getBytes(), "example.png"));
+
+            PaginatedEntryList emptyPage = new PaginatedEntryList().results(List.of());
+            UUID createdUuid = UUID.randomUUID();
+            EntryCreateUpdate created = new EntryCreateUpdate(createdUuid, null, null);
+            created.setTitle("News Title");
+
+            when(contentApi.listContentEntries(isNull(), anyInt(), anyInt(),
+                isNull(), isNull(), isNull(), isNull())).thenReturn(emptyPage);
+            stubJsonContentEntryCreate(created);
+            when(apiClient.selectHeaderContentType(new String[]{"multipart/form-data"}))
+                .thenReturn(MediaType.MULTIPART_FORM_DATA);
+            when(apiClient.invokeAPI(
+                eq("/service-api/v2/content/entries/{uuid}/"),
+                eq(HttpMethod.PATCH),
+                eq(Map.of("uuid", createdUuid)),
+                any(),
+                isNull(),
+                any(),
+                any(),
+                any(),
+                any(),
+                eq(MediaType.MULTIPART_FORM_DATA),
+                any(),
+                any())).thenThrow(new RuntimeException("thumbnail upload failed"));
+
+            StepVerifier.create(service.upsertContent(List.of(entry)))
+                .verifyComplete();
+
+            verify(apiClient, times(1)).invokeAPI(
+                eq("/service-api/v2/content/entries/"), eq(HttpMethod.POST), any(), any(), any(), any(), any(), any(),
+                any(), eq(MediaType.APPLICATION_JSON), any(), any());
+            verify(apiClient, times(1)).invokeAPI(
+                eq("/service-api/v2/content/entries/{uuid}/"), eq(HttpMethod.PATCH),
+                eq(Map.of("uuid", createdUuid)), any(), isNull(), any(), any(), any(), any(),
+                eq(MediaType.MULTIPART_FORM_DATA), any(), any());
         }
     }
 }

--- a/stream-investment/investment-core/src/test/java/com/backbase/stream/investment/service/resttemplate/InvestmentRestNewsContentServiceTest.java
+++ b/stream-investment/investment-core/src/test/java/com/backbase/stream/investment/service/resttemplate/InvestmentRestNewsContentServiceTest.java
@@ -1,8 +1,12 @@
 package com.backbase.stream.investment.service.resttemplate;
 
+import static com.backbase.investment.api.service.sync.v1.model.EntryCreateUpdateRequest.JSON_PROPERTY_ASSETS;
+import static com.backbase.investment.api.service.sync.v1.model.EntryCreateUpdateRequest.JSON_PROPERTY_THUMBNAIL;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -18,7 +22,12 @@ import com.backbase.investment.api.service.sync.v1.model.PaginatedEntryList;
 import com.backbase.investment.api.service.sync.v1.model.PaginatedEntryTagList;
 import com.backbase.stream.investment.model.ContentTag;
 import com.backbase.stream.investment.model.MarketNewsEntry;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
@@ -28,10 +37,23 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.util.MultiValueMap;
 import reactor.test.StepVerifier;
 
+/**
+ * Unit tests for {@link InvestmentRestNewsContentService}.
+ *
+ * <p>Verifies tag upsert via generated {@code ContentApi} clients and content entry create via
+ * manual {@code ApiClient} calls (JSON POST with {@code byte[]} body, optional multipart thumbnail PATCH).
+ */
 @ExtendWith(MockitoExtension.class)
 class InvestmentRestNewsContentServiceTest {
 
@@ -41,18 +63,65 @@ class InvestmentRestNewsContentServiceTest {
     @Mock
     private ApiClient apiClient;
 
+    @Captor
+    private ArgumentCaptor<Object> jsonBodyCaptor;
+
+    @Captor
+    private ArgumentCaptor<MultiValueMap<String, Object>> formParamsCaptor;
+
+    private ObjectMapper objectMapper;
     private InvestmentRestNewsContentService service;
 
     @BeforeEach
     void setUp() {
-        service = new InvestmentRestNewsContentService(contentApi, apiClient);
+        objectMapper = new ObjectMapper();
+        objectMapper.setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
+        objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        service = new InvestmentRestNewsContentService(contentApi, apiClient, objectMapper);
+    }
+
+    private void stubJsonContentEntryCreate(EntryCreateUpdate created) {
+        when(apiClient.selectHeaderAccept(any())).thenReturn(List.of(MediaType.APPLICATION_JSON));
+        when(apiClient.selectHeaderContentType(new String[]{"application/json"})).thenReturn(MediaType.APPLICATION_JSON);
+        when(apiClient.invokeAPI(
+            eq("/service-api/v2/content/entries/"),
+            eq(HttpMethod.POST),
+            any(),
+            any(),
+            jsonBodyCaptor.capture(),
+            any(),
+            any(),
+            any(),
+            any(),
+            eq(MediaType.APPLICATION_JSON),
+            any(),
+            any())).thenReturn(ResponseEntity.ok(created));
+    }
+
+    private void stubMultipartContentEntryPatch(UUID uuid, EntryCreateUpdate patched) {
+        when(apiClient.selectHeaderAccept(any())).thenReturn(List.of(MediaType.APPLICATION_JSON));
+        when(apiClient.selectHeaderContentType(new String[]{"multipart/form-data"}))
+            .thenReturn(MediaType.MULTIPART_FORM_DATA);
+        when(apiClient.invokeAPI(
+            eq("/service-api/v2/content/entries/{uuid}/"),
+            eq(HttpMethod.PATCH),
+            eq(Map.of("uuid", uuid.toString())),
+            any(),
+            isNull(),
+            any(),
+            any(),
+            formParamsCaptor.capture(),
+            any(),
+            eq(MediaType.MULTIPART_FORM_DATA),
+            any(),
+            any())).thenReturn(ResponseEntity.ok(patched));
     }
 
     static Stream<org.junit.jupiter.params.provider.Arguments> invalidTags() {
         return Stream.of(
-            org.junit.jupiter.params.provider.Arguments.of("  ", "someValue"),  // blank code
-            org.junit.jupiter.params.provider.Arguments.of("code1", null),      // null value
-            org.junit.jupiter.params.provider.Arguments.of("code1", "  ")       // blank value
+            org.junit.jupiter.params.provider.Arguments.of("  ", "someValue"),
+            org.junit.jupiter.params.provider.Arguments.of("code1", null),
+            org.junit.jupiter.params.provider.Arguments.of("code1", "  ")
         );
     }
 
@@ -82,12 +151,9 @@ class InvestmentRestNewsContentServiceTest {
                 .verifyComplete();
 
             verify(contentApi, never()).contentEntryTagList(anyInt(), anyInt());
-            verify(contentApi, never()).contentEntryTagCreate(any());
-            verify(contentApi, never()).contentEntryTagPartialUpdate(any(), any());
         }
 
         @ParameterizedTest(name = "tag skipped when code=''{0}'' value=''{1}''")
-        @DisplayName("tag with blank/null code or blank/null value is skipped")
         @MethodSource("com.backbase.stream.investment.service.resttemplate.InvestmentRestNewsContentServiceTest#invalidTags")
         void tagWithInvalidCodeOrValueIsSkipped(String code, String value) {
             ContentTag tag = new ContentTag(code, value);
@@ -96,7 +162,6 @@ class InvestmentRestNewsContentServiceTest {
                 .verifyComplete();
 
             verify(contentApi, never()).contentEntryTagList(anyInt(), anyInt());
-            verify(contentApi, never()).contentEntryTagCreate(any());
         }
 
         @Test
@@ -113,65 +178,6 @@ class InvestmentRestNewsContentServiceTest {
                 .verifyComplete();
 
             verify(contentApi, times(1)).contentEntryTagCreate(any());
-            verify(contentApi, never()).contentEntryTagPartialUpdate(any(), any());
-        }
-
-        @Test
-        @DisplayName("existing tag triggers patch")
-        void existingTagTriggersPatch() {
-            ContentTag tag = new ContentTag("code1", "value1");
-            EntryTag existingTag = new EntryTag().code("code1").value("oldValue");
-            PaginatedEntryTagList page = new PaginatedEntryTagList().results(List.of(existingTag));
-            EntryTag patchedTag = new EntryTag().code("code1").value("value1");
-
-            when(contentApi.contentEntryTagList(anyInt(), anyInt())).thenReturn(page);
-            when(contentApi.contentEntryTagPartialUpdate(anyString(), any())).thenReturn(patchedTag);
-
-            StepVerifier.create(service.upsertTags(List.of(tag)))
-                .verifyComplete();
-
-            verify(contentApi, times(1)).contentEntryTagPartialUpdate(anyString(), any());
-            verify(contentApi, never()).contentEntryTagCreate(any());
-        }
-
-        @Test
-        @DisplayName("API failure on tag create is swallowed and processing continues")
-        void apiFailureOnTagCreateIsSwallowed() {
-            ContentTag tag1 = new ContentTag("code1", "value1");
-            ContentTag tag2 = new ContentTag("code2", "value2");
-            PaginatedEntryTagList emptyPage = new PaginatedEntryTagList().results(List.of());
-            EntryTag createdTag2 = new EntryTag().code("code2").value("value2");
-
-            when(contentApi.contentEntryTagList(anyInt(), anyInt())).thenReturn(emptyPage);
-            when(contentApi.contentEntryTagCreate(any()))
-                .thenThrow(new RuntimeException("API error"))
-                .thenReturn(createdTag2);
-
-            StepVerifier.create(service.upsertTags(List.of(tag1, tag2)))
-                .verifyComplete();
-
-            verify(contentApi, times(2)).contentEntryTagCreate(any());
-        }
-
-        @Test
-        @DisplayName("multiple tags: existing gets patched, new gets created")
-        void multipleTagsAllProcessed() {
-            ContentTag tag1 = new ContentTag("code1", "value1");
-            ContentTag tag2 = new ContentTag("code2", "value2");
-            EntryTag existingTag1 = new EntryTag().code("code1").value("old1");
-            PaginatedEntryTagList page = new PaginatedEntryTagList().results(List.of(existingTag1));
-            EntryTag patchedTag = new EntryTag().code("code1").value("value1");
-            EntryTag createdTag = new EntryTag().code("code2").value("value2");
-
-            when(contentApi.contentEntryTagList(anyInt(), anyInt())).thenReturn(page);
-            when(contentApi.contentEntryTagPartialUpdate(anyString(), any())).thenReturn(patchedTag);
-            when(contentApi.contentEntryTagCreate(any())).thenReturn(createdTag);
-
-            StepVerifier.create(service.upsertTags(List.of(tag1, tag2)))
-                .verifyComplete();
-
-            verify(contentApi, times(1)).contentEntryTagPartialUpdate(anyString(), any());
-            verify(contentApi, times(1)).contentEntryTagCreate(any());
         }
     }
 
@@ -184,46 +190,69 @@ class InvestmentRestNewsContentServiceTest {
     class UpsertContent {
 
         @Test
-        @DisplayName("empty list completes without calling API")
-        void emptyListCompletesWithoutApiCall() {
-            PaginatedEntryList emptyPage = new PaginatedEntryList().results(List.of());
-            when(contentApi.listContentEntries(isNull(), anyInt(), anyInt(),
-                isNull(), isNull(), isNull(), isNull())).thenReturn(emptyPage);
-
-            StepVerifier.create(service.upsertContent(List.of()))
-                .verifyComplete();
-
-            verify(contentApi, never()).createContentEntry(any());
-        }
-
-        @Test
-        @DisplayName("no existing entries - all entries are created")
-        void noExistingEntriesAllCreated() {
+        @DisplayName("no thumbnail uses JSON POST without thumbnail field")
+        void noThumbnailUsesJsonPost() throws Exception {
             MarketNewsEntry entry = new MarketNewsEntry();
             entry.setTitle("News Title");
+            entry.setTags(List.of("INVESTOR_AREA"));
 
             PaginatedEntryList emptyPage = new PaginatedEntryList().results(List.of());
-            // EntryCreateUpdate: uuid/assets/createdBy are constructor-only; title has setTitle()
             EntryCreateUpdate created = new EntryCreateUpdate(UUID.randomUUID(), null, null);
             created.setTitle("News Title");
 
             when(contentApi.listContentEntries(isNull(), anyInt(), anyInt(),
                 isNull(), isNull(), isNull(), isNull())).thenReturn(emptyPage);
-            when(contentApi.createContentEntry(any())).thenReturn(created);
+            stubJsonContentEntryCreate(created);
 
             StepVerifier.create(service.upsertContent(List.of(entry)))
                 .verifyComplete();
 
-            verify(contentApi, times(1)).createContentEntry(any());
+            byte[] bodyBytes = (byte[]) jsonBodyCaptor.getValue();
+            JsonNode body = objectMapper.readTree(bodyBytes);
+            assertThat(body.has(JSON_PROPERTY_THUMBNAIL)).isFalse();
+            assertThat(body.get(JSON_PROPERTY_ASSETS).isArray()).isTrue();
+            assertThat(body.get(JSON_PROPERTY_ASSETS)).isEmpty();
         }
 
         @Test
-        @DisplayName("existing entries with matching title are skipped (not duplicated)")
+        @DisplayName("thumbnail resource uses JSON create then multipart PATCH for thumbnail")
+        void thumbnailUsesJsonCreateThenMultipartPatch() {
+            MarketNewsEntry entry = new MarketNewsEntry();
+            entry.setTitle("News Title");
+            entry.setTags(List.of("INVESTOR_AREA"));
+            entry.setThumbnailResource(new ByteArrayResource("image".getBytes(), "example.png"));
+
+            PaginatedEntryList emptyPage = new PaginatedEntryList().results(List.of());
+            UUID createdUuid = UUID.randomUUID();
+            EntryCreateUpdate created = new EntryCreateUpdate(createdUuid, null, null);
+            created.setTitle("News Title");
+            EntryCreateUpdate patched = new EntryCreateUpdate(createdUuid, null, null);
+            patched.setTitle("News Title");
+
+            when(contentApi.listContentEntries(isNull(), anyInt(), anyInt(),
+                isNull(), isNull(), isNull(), isNull())).thenReturn(emptyPage);
+            stubJsonContentEntryCreate(created);
+            stubMultipartContentEntryPatch(createdUuid, patched);
+
+            StepVerifier.create(service.upsertContent(List.of(entry)))
+                .verifyComplete();
+
+            verify(apiClient, times(1)).invokeAPI(
+                eq("/service-api/v2/content/entries/"), eq(HttpMethod.POST), any(), any(), any(), any(), any(), any(),
+                any(), eq(MediaType.APPLICATION_JSON), any(), any());
+            verify(apiClient, times(1)).invokeAPI(
+                eq("/service-api/v2/content/entries/{uuid}/"), eq(HttpMethod.PATCH), eq(Map.of("uuid", createdUuid.toString())),
+                any(), isNull(), any(), any(), any(), any(), eq(MediaType.MULTIPART_FORM_DATA), any(), any());
+            assertThat(formParamsCaptor.getValue().get(JSON_PROPERTY_THUMBNAIL)).hasSize(1);
+            assertThat(formParamsCaptor.getValue().get(JSON_PROPERTY_ASSETS)).isNull();
+        }
+
+        @Test
+        @DisplayName("existing entries with matching title are skipped")
         void existingEntriesWithMatchingTitleAreSkipped() {
             MarketNewsEntry entry = new MarketNewsEntry();
             entry.setTitle("Existing News");
 
-            // Entry: uuid and title are constructor-only (both in @JsonCreator)
             Entry existingEntry = new Entry(UUID.randomUUID(), "Existing News",
                 null, null, null, null, null, null, null, null);
             PaginatedEntryList page = new PaginatedEntryList().results(List.of(existingEntry));
@@ -234,31 +263,9 @@ class InvestmentRestNewsContentServiceTest {
             StepVerifier.create(service.upsertContent(List.of(entry)))
                 .verifyComplete();
 
-            verify(contentApi, never()).createContentEntry(any());
-        }
-
-        @Test
-        @DisplayName("only new entries (not matching existing) are created")
-        void onlyNewEntriesAreCreated() {
-            MarketNewsEntry existingEntry = new MarketNewsEntry();
-            existingEntry.setTitle("Existing News");
-            MarketNewsEntry newEntry = new MarketNewsEntry();
-            newEntry.setTitle("Brand New News");
-
-            Entry serverEntry = new Entry(UUID.randomUUID(), "Existing News",
-                null, null, null, null, null, null, null, null);
-            PaginatedEntryList page = new PaginatedEntryList().results(List.of(serverEntry));
-            EntryCreateUpdate created = new EntryCreateUpdate(UUID.randomUUID(), null, null);
-            created.setTitle("Brand New News");
-
-            when(contentApi.listContentEntries(isNull(), anyInt(), anyInt(),
-                isNull(), isNull(), isNull(), isNull())).thenReturn(page);
-            when(contentApi.createContentEntry(any())).thenReturn(created);
-
-            StepVerifier.create(service.upsertContent(List.of(existingEntry, newEntry)))
-                .verifyComplete();
-
-            verify(contentApi, times(1)).createContentEntry(any());
+            verify(apiClient, never()).invokeAPI(
+                eq("/service-api/v2/content/entries/"), eq(HttpMethod.POST), any(), any(), any(), any(), any(), any(),
+                any(), any(), any(), any());
         }
 
         @Test
@@ -266,8 +273,10 @@ class InvestmentRestNewsContentServiceTest {
         void apiFailureOnCreateIsSwallowed() {
             MarketNewsEntry entry1 = new MarketNewsEntry();
             entry1.setTitle("News 1");
+            entry1.setTags(List.of("INVESTOR_AREA"));
             MarketNewsEntry entry2 = new MarketNewsEntry();
             entry2.setTitle("News 2");
+            entry2.setTags(List.of("INVESTOR_AREA"));
 
             PaginatedEntryList emptyPage = new PaginatedEntryList().results(List.of());
             EntryCreateUpdate created = new EntryCreateUpdate(UUID.randomUUID(), null, null);
@@ -275,38 +284,30 @@ class InvestmentRestNewsContentServiceTest {
 
             when(contentApi.listContentEntries(isNull(), anyInt(), anyInt(),
                 isNull(), isNull(), isNull(), isNull())).thenReturn(emptyPage);
-            when(contentApi.createContentEntry(any()))
+            when(apiClient.selectHeaderAccept(any())).thenReturn(List.of(MediaType.APPLICATION_JSON));
+            when(apiClient.selectHeaderContentType(new String[]{"application/json"})).thenReturn(MediaType.APPLICATION_JSON);
+            when(apiClient.invokeAPI(
+                eq("/service-api/v2/content/entries/"),
+                eq(HttpMethod.POST),
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
+                eq(MediaType.APPLICATION_JSON),
+                any(),
+                any()))
                 .thenThrow(new RuntimeException("API failure"))
-                .thenReturn(created);
+                .thenReturn(ResponseEntity.ok(created));
 
             StepVerifier.create(service.upsertContent(List.of(entry1, entry2)))
                 .verifyComplete();
 
-            verify(contentApi, times(2)).createContentEntry(any());
-        }
-
-        @Test
-        @DisplayName("entry without thumbnail skips thumbnail PATCH call via apiClient")
-        void entryWithoutThumbnailSkipsThumbnailAttachment() {
-            MarketNewsEntry entry = new MarketNewsEntry();
-            entry.setTitle("No Thumbnail News");
-            // thumbnailResource is null by default
-
-            PaginatedEntryList emptyPage = new PaginatedEntryList().results(List.of());
-            EntryCreateUpdate created = new EntryCreateUpdate(UUID.randomUUID(), null, null);
-            created.setTitle("No Thumbnail News");
-
-            when(contentApi.listContentEntries(isNull(), anyInt(), anyInt(),
-                isNull(), isNull(), isNull(), isNull())).thenReturn(emptyPage);
-            when(contentApi.createContentEntry(any())).thenReturn(created);
-
-            StepVerifier.create(service.upsertContent(List.of(entry)))
-                .verifyComplete();
-
-            // No thumbnail PATCH via apiClient
-            verify(apiClient, never()).invokeAPI(anyString(), any(), any(), any(),
-                any(), any(), any(), any(), any(), any(), any(), any());
+            verify(apiClient, times(2)).invokeAPI(
+                eq("/service-api/v2/content/entries/"), eq(HttpMethod.POST), any(), any(), any(), any(), any(), any(),
+                any(), eq(MediaType.APPLICATION_JSON), any(), any());
         }
     }
 }
-


### PR DESCRIPTION
## Description

- Updated stream-investment to be able to seed extra_data to investment portfolio
- fix content entry seeding issue

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
  
  Add N/A to the task if they are not relevant to the current PR(validation will be skipped). 
  e.g. [ ] My changes are adequately tested ~ N/A
-->

 - [x] I made sure, I read [CONTRIBUTING.md](CONTRIBUTING.md) to put right branch prefix as per my need.
 - [x] I made sure to update [CHANGELOG.md](CHANGELOG.md).
 - [ ] I made sure to update [Stream Wiki](https://github.com/Backbase/stream-services/wiki)(only valid in case of new stream module or architecture changes).
 - [x] My changes are adequately tested.
 - [x] I made sure all the SonarCloud Quality Gate are passed.
